### PR TITLE
CRUD 구현

### DIFF
--- a/src/main/java/org/example/cinemanote/domain/archive/controller/ArchiveController.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/controller/ArchiveController.java
@@ -1,0 +1,68 @@
+package org.example.cinemanote.domain.archive.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.cinemanote.auth.annotation.AuthUser;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveUpdateRequest;
+import org.example.cinemanote.domain.archive.dto.response.ArchiveResponse;
+import org.example.cinemanote.domain.archive.service.ArchiveService;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.global.response.ApiResponse;
+import org.example.cinemanote.global.response.PageResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/archives")
+@RequiredArgsConstructor
+public class ArchiveController {
+
+    private final ArchiveService archiveService;
+
+    @PostMapping
+    //@ResponseStatus(HttpStatus.CREATED)
+    public Mono<ApiResponse<ArchiveResponse>> createArchive(
+            @AuthUser User currentUser,
+            @Valid @RequestBody ArchiveCreateRequest request
+    ) {
+        return archiveService.createArchive(currentUser, request).map(ApiResponse::ok);
+    }
+
+    @GetMapping
+    public ApiResponse<PageResponse<ArchiveResponse>> getArchives(
+            @AuthUser User currentUser,
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable
+    ) {
+        return ApiResponse.ok(archiveService.getArchives(currentUser, pageable));
+    }
+
+    @GetMapping("/{archiveId}")
+    public ApiResponse<ArchiveResponse> getArchive(
+            @AuthUser User currentUser,
+            @PathVariable Long archiveId
+    ) {
+        return ApiResponse.ok(archiveService.getArchive(currentUser, archiveId));
+    }
+
+    @DeleteMapping("/{archiveId}")
+    public ApiResponse<Void> deleteArchive(
+            @AuthUser User currentUser,
+            @PathVariable Long archiveId
+    ) {
+        archiveService.deleteArchive(currentUser, archiveId);
+        return ApiResponse.ok(null);
+    }
+
+    @PatchMapping("/{archiveId}")
+    public ApiResponse<ArchiveResponse> updateArchive(
+            @AuthUser User currentUser,
+            @PathVariable Long archiveId,
+            @Valid @RequestBody ArchiveUpdateRequest request
+    ) {
+        return ApiResponse.ok(archiveService.updateArchive(currentUser, archiveId, request));
+    }
+}

--- a/src/main/java/org/example/cinemanote/domain/archive/controller/ArchiveController.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/controller/ArchiveController.java
@@ -24,7 +24,7 @@ public class ArchiveController {
     private final ArchiveService archiveService;
 
     @PostMapping
-    //@ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.CREATED)
     public Mono<ApiResponse<ArchiveResponse>> createArchive(
             @AuthUser User currentUser,
             @Valid @RequestBody ArchiveCreateRequest request

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveCreateRequest.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveCreateRequest.java
@@ -1,5 +1,7 @@
 package org.example.cinemanote.domain.archive.dto.request;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -15,6 +17,8 @@ public class ArchiveCreateRequest {
     @NotNull
     private ContentType contentType;
 
+    @DecimalMin("0.0")
+    @DecimalMax("10.0")
     private float rating;
 
     @Size(max = 500)

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveCreateRequest.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveCreateRequest.java
@@ -1,0 +1,22 @@
+package org.example.cinemanote.domain.archive.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ArchiveCreateRequest {
+
+    public enum ContentType { MOVIE, TV }
+
+    @NotNull
+    private Long tmdbId;
+
+    @NotNull
+    private ContentType contentType;
+
+    private float raiting;
+
+    @Size(max = 500)
+    private String review;
+}

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveCreateRequest.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveCreateRequest.java
@@ -15,7 +15,7 @@ public class ArchiveCreateRequest {
     @NotNull
     private ContentType contentType;
 
-    private float raiting;
+    private float rating;
 
     @Size(max = 500)
     private String review;

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveUpdateRequest.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveUpdateRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class ArchiveUpdateRequest {
 
-    private float raiting;
+    private float rating;
 
     @Size(max = 500)
     private String review;

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveUpdateRequest.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveUpdateRequest.java
@@ -1,0 +1,13 @@
+package org.example.cinemanote.domain.archive.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ArchiveUpdateRequest {
+
+    private float raiting;
+
+    @Size(max = 500)
+    private String review;
+}

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveUpdateRequest.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/request/ArchiveUpdateRequest.java
@@ -1,11 +1,15 @@
 package org.example.cinemanote.domain.archive.dto.request;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class ArchiveUpdateRequest {
 
+    @DecimalMin("0.0")
+    @DecimalMax("10.0")
     private float rating;
 
     @Size(max = 500)

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/response/ArchiveResponse.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/response/ArchiveResponse.java
@@ -1,0 +1,39 @@
+package org.example.cinemanote.domain.archive.dto.response;
+
+import lombok.Getter;
+import org.example.cinemanote.domain.archive.entity.Archive;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class ArchiveResponse {
+
+    private final Long id;
+    private final Long userId;
+    private final String title;
+    private final String posterPath;
+    private final String overview;
+    private final LocalDate releaseDate;
+    private final float raiting;
+    private final String review;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    private ArchiveResponse(Archive archive) {
+        this.id = archive.getId();
+        this.userId = archive.getUser().getId();
+        this.title = archive.getTitle();
+        this.posterPath = archive.getPosterPath();
+        this.overview = archive.getOverview();
+        this.releaseDate = archive.getReleaseDate();
+        this.raiting = archive.getRaiting();
+        this.review = archive.getReview();
+        this.createdAt = archive.getCreatedAt();
+        this.updatedAt = archive.getUpdatedAt();
+    }
+
+    public static ArchiveResponse from(Archive archive) {
+        return new ArchiveResponse(archive);
+    }
+}

--- a/src/main/java/org/example/cinemanote/domain/archive/dto/response/ArchiveResponse.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/dto/response/ArchiveResponse.java
@@ -15,7 +15,7 @@ public class ArchiveResponse {
     private final String posterPath;
     private final String overview;
     private final LocalDate releaseDate;
-    private final float raiting;
+    private final float rating;
     private final String review;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
@@ -27,7 +27,7 @@ public class ArchiveResponse {
         this.posterPath = archive.getPosterPath();
         this.overview = archive.getOverview();
         this.releaseDate = archive.getReleaseDate();
-        this.raiting = archive.getRaiting();
+        this.rating = archive.getRating();
         this.review = archive.getReview();
         this.createdAt = archive.getCreatedAt();
         this.updatedAt = archive.getUpdatedAt();

--- a/src/main/java/org/example/cinemanote/domain/archive/entity/Archive.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/entity/Archive.java
@@ -1,11 +1,15 @@
 package org.example.cinemanote.domain.archive.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
 import org.example.cinemanote.domain.user.entity.User;
 import org.example.cinemanote.global.common.BaseEntity;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
 
@@ -24,6 +28,13 @@ public class Archive extends BaseEntity {
     private User user;
 
     @Column(nullable = false)
+    private Long tmdbId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ContentType contentType;
+
+    @Column(nullable = false)
     private String title;
 
     private String posterPath;
@@ -33,13 +44,17 @@ public class Archive extends BaseEntity {
 
     private LocalDate releaseDate;
 
+    @Column(nullable = false)
+    @ColumnDefault("0.0")
     private float rating;
 
     @Column(length = 500)
     private String review;
 
-    private Archive(User user, String title, String posterPath, String overview, LocalDate releaseDate, float rating, String review) {
+    private Archive(User user, Long tmdbId, ContentType contentType, String title, String posterPath, String overview, LocalDate releaseDate, float rating, String review) {
         this.user = user;
+        this.tmdbId = tmdbId;
+        this.contentType = contentType;
         this.title = title;
         this.posterPath = posterPath;
         this.overview = overview;
@@ -48,8 +63,8 @@ public class Archive extends BaseEntity {
         this.review = review;
     }
 
-    public static Archive of(User user, String title, String posterPath, String overview, LocalDate releaseDate, float rating, String review) {
-        return new Archive(user, title, posterPath, overview, releaseDate, rating, review);
+    public static Archive of(User user, Long tmdbId, ContentType contentType, String title, String posterPath, String overview, LocalDate releaseDate, float rating, String review) {
+        return new Archive(user, tmdbId, contentType, title, posterPath, overview, releaseDate, rating, review);
     }
 
     public void update(float rating, String review) {

--- a/src/main/java/org/example/cinemanote/domain/archive/entity/Archive.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/entity/Archive.java
@@ -33,27 +33,27 @@ public class Archive extends BaseEntity {
 
     private LocalDate releaseDate;
 
-    private float raiting;
+    private float rating;
 
     @Column(length = 500)
     private String review;
 
-    private Archive(User user, String title, String posterPath, String overview, LocalDate releaseDate, float raiting, String review) {
+    private Archive(User user, String title, String posterPath, String overview, LocalDate releaseDate, float rating, String review) {
         this.user = user;
         this.title = title;
         this.posterPath = posterPath;
         this.overview = overview;
         this.releaseDate = releaseDate;
-        this.raiting = raiting;
+        this.rating = rating;
         this.review = review;
     }
 
-    public static Archive of(User user, String title, String posterPath, String overview, LocalDate releaseDate, float raiting, String review) {
-        return new Archive(user, title, posterPath, overview, releaseDate, raiting, review);
+    public static Archive of(User user, String title, String posterPath, String overview, LocalDate releaseDate, float rating, String review) {
+        return new Archive(user, title, posterPath, overview, releaseDate, rating, review);
     }
 
-    public void update(float raiting, String review) {
-        this.raiting = raiting;
+    public void update(float rating, String review) {
+        this.rating = rating;
         this.review = review;
     }
 }

--- a/src/main/java/org/example/cinemanote/domain/archive/entity/Archive.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/entity/Archive.java
@@ -1,0 +1,59 @@
+package org.example.cinemanote.domain.archive.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.global.common.BaseEntity;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "archives")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Archive extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String posterPath;
+
+    @Column(length = 500)
+    private String overview;
+
+    private LocalDate releaseDate;
+
+    private float raiting;
+
+    @Column(length = 500)
+    private String review;
+
+    private Archive(User user, String title, String posterPath, String overview, LocalDate releaseDate, float raiting, String review) {
+        this.user = user;
+        this.title = title;
+        this.posterPath = posterPath;
+        this.overview = overview;
+        this.releaseDate = releaseDate;
+        this.raiting = raiting;
+        this.review = review;
+    }
+
+    public static Archive of(User user, String title, String posterPath, String overview, LocalDate releaseDate, float raiting, String review) {
+        return new Archive(user, title, posterPath, overview, releaseDate, raiting, review);
+    }
+
+    public void update(float raiting, String review) {
+        this.raiting = raiting;
+        this.review = review;
+    }
+}

--- a/src/main/java/org/example/cinemanote/domain/archive/repository/ArchiveRepository.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/repository/ArchiveRepository.java
@@ -1,5 +1,6 @@
 package org.example.cinemanote.domain.archive.repository;
 
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
 import org.example.cinemanote.domain.archive.entity.Archive;
 import org.example.cinemanote.domain.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -8,4 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArchiveRepository extends JpaRepository<Archive, Long> {
     Page<Archive> findAllByUser(User user, Pageable pageable);
+    boolean existsByUserAndTmdbIdAndContentType(User user, Long tmdbId, ContentType contentType);
 }

--- a/src/main/java/org/example/cinemanote/domain/archive/repository/ArchiveRepository.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/repository/ArchiveRepository.java
@@ -1,0 +1,11 @@
+package org.example.cinemanote.domain.archive.repository;
+
+import org.example.cinemanote.domain.archive.entity.Archive;
+import org.example.cinemanote.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArchiveRepository extends JpaRepository<Archive, Long> {
+    Page<Archive> findAllByUser(User user, Pageable pageable);
+}

--- a/src/main/java/org/example/cinemanote/domain/archive/service/ArchiveService.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/service/ArchiveService.java
@@ -31,12 +31,18 @@ public class ArchiveService {
     private final TmdbTvService tmdbTvService;
 
     public Mono<ArchiveResponse> createArchive(User user, ArchiveCreateRequest request) {
+        if (archiveRepository.existsByUserAndTmdbIdAndContentType(user, request.getTmdbId(), request.getContentType())) {
+            throw new CustomException(ErrorCode.ARCHIVE_ALREADY_EXISTS);
+        }
+
         Mono<Archive> archiveMono;
 
         if (request.getContentType() == ContentType.MOVIE) {
             archiveMono = tmdbMovieService.getMovieDetail(request.getTmdbId(), null)
                     .map(tmdb -> Archive.of(
                             user,
+                            request.getTmdbId(),
+                            request.getContentType(),
                             tmdb.getTitle(),
                             tmdb.getPosterPath(),
                             tmdb.getOverview(),
@@ -48,6 +54,8 @@ public class ArchiveService {
             archiveMono = tmdbTvService.getTvDetail(request.getTmdbId(), null)
                     .map(tmdb -> Archive.of(
                             user,
+                            request.getTmdbId(),
+                            request.getContentType(),
                             tmdb.getName(),
                             tmdb.getPosterPath(),
                             tmdb.getOverview(),

--- a/src/main/java/org/example/cinemanote/domain/archive/service/ArchiveService.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/service/ArchiveService.java
@@ -41,7 +41,7 @@ public class ArchiveService {
                             tmdb.getPosterPath(),
                             tmdb.getOverview(),
                             parseDate(tmdb.getReleaseDate()),
-                            request.getRaiting(),
+                            request.getRating(),
                             request.getReview()
                     ));
         } else {
@@ -52,7 +52,7 @@ public class ArchiveService {
                             tmdb.getPosterPath(),
                             tmdb.getOverview(),
                             parseDate(tmdb.getFirstAirDate()),
-                            request.getRaiting(),
+                            request.getRating(),
                             request.getReview()
                     ));
         }
@@ -87,7 +87,7 @@ public class ArchiveService {
         Archive archive = archiveRepository.findById(archiveId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ARCHIVE_NOT_FOUND));
         validateOwnership(user, archive);
-        archive.update(request.getRaiting(), request.getReview());
+        archive.update(request.getRating(), request.getReview());
         return ArchiveResponse.from(archive);
     }
 

--- a/src/main/java/org/example/cinemanote/domain/archive/service/ArchiveService.java
+++ b/src/main/java/org/example/cinemanote/domain/archive/service/ArchiveService.java
@@ -1,0 +1,104 @@
+package org.example.cinemanote.domain.archive.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveUpdateRequest;
+import org.example.cinemanote.domain.archive.dto.response.ArchiveResponse;
+import org.example.cinemanote.domain.archive.entity.Archive;
+import org.example.cinemanote.domain.archive.repository.ArchiveRepository;
+import org.example.cinemanote.domain.tmdb.service.TmdbMovieService;
+import org.example.cinemanote.global.response.PageResponse;
+import org.example.cinemanote.domain.tmdb.service.TmdbTvService;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Pageable;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArchiveService {
+
+    private final ArchiveRepository archiveRepository;
+    private final TmdbMovieService tmdbMovieService;
+    private final TmdbTvService tmdbTvService;
+
+    public Mono<ArchiveResponse> createArchive(User user, ArchiveCreateRequest request) {
+        Mono<Archive> archiveMono;
+
+        if (request.getContentType() == ContentType.MOVIE) {
+            archiveMono = tmdbMovieService.getMovieDetail(request.getTmdbId(), null)
+                    .map(tmdb -> Archive.of(
+                            user,
+                            tmdb.getTitle(),
+                            tmdb.getPosterPath(),
+                            tmdb.getOverview(),
+                            parseDate(tmdb.getReleaseDate()),
+                            request.getRaiting(),
+                            request.getReview()
+                    ));
+        } else {
+            archiveMono = tmdbTvService.getTvDetail(request.getTmdbId(), null)
+                    .map(tmdb -> Archive.of(
+                            user,
+                            tmdb.getName(),
+                            tmdb.getPosterPath(),
+                            tmdb.getOverview(),
+                            parseDate(tmdb.getFirstAirDate()),
+                            request.getRaiting(),
+                            request.getReview()
+                    ));
+        }
+
+        return archiveMono
+                .flatMap(archive -> Mono.fromCallable(() -> archiveRepository.save(archive))
+                        .subscribeOn(Schedulers.boundedElastic()))
+                .map(ArchiveResponse::from);
+    }
+
+    public ArchiveResponse getArchive(User user, Long archiveId) {
+        Archive archive = archiveRepository.findById(archiveId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARCHIVE_NOT_FOUND));
+        validateOwnership(user, archive);
+        return ArchiveResponse.from(archive);
+    }
+
+    public PageResponse<ArchiveResponse> getArchives(User user, Pageable pageable) {
+        return PageResponse.from(archiveRepository.findAllByUser(user, pageable).map(ArchiveResponse::from));
+    }
+
+    @Transactional
+    public void deleteArchive(User user, Long archiveId) {
+        Archive archive = archiveRepository.findById(archiveId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARCHIVE_NOT_FOUND));
+        validateOwnership(user, archive);
+        archiveRepository.delete(archive);
+    }
+
+    @Transactional
+    public ArchiveResponse updateArchive(User user, Long archiveId, ArchiveUpdateRequest request) {
+        Archive archive = archiveRepository.findById(archiveId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ARCHIVE_NOT_FOUND));
+        validateOwnership(user, archive);
+        archive.update(request.getRaiting(), request.getReview());
+        return ArchiveResponse.from(archive);
+    }
+
+    private void validateOwnership(User user, Archive archive) {
+        if (!archive.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ARCHIVE_ACCESS_DENIED);
+        }
+    }
+
+    private LocalDate parseDate(String date) {
+        if (date == null || date.isBlank()) return null;
+        return LocalDate.parse(date);
+    }
+}

--- a/src/main/java/org/example/cinemanote/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/cinemanote/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     // 아카이브
     ARCHIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 아카이브입니다"),
     ARCHIVE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 아카이브에 접근 권한이 없습니다"),
+    ARCHIVE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 저장된 아카이브입니다"),
 
     // 단축 URL
     SHORT_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 단축 링크입니다"),

--- a/src/main/java/org/example/cinemanote/global/response/PageResponse.java
+++ b/src/main/java/org/example/cinemanote/global/response/PageResponse.java
@@ -1,0 +1,30 @@
+package org.example.cinemanote.global.response;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponse<T> {
+
+    private final List<T> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean last;
+
+    private PageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.last = page.isLast();
+    }
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(page);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 간단히 설명해 주세요 -->
아카이브 도메인의 CRUD 기능을 구현합니다.

## 🔗 관련 이슈
<!-- closes #이슈번호 를 적으면 merge 시 이슈가 자동으로 닫힙니다 -->
closes #9

## ✅ 변경 사항
<!-- 구체적으로 어떤 것들이 변경되었는지 체크리스트로 작성해 주세요 -->
- [x] 아카이브 엔티티를 구현합니다.
- [x] 조회, 생성, 수정. 삭제를 위한 API, 관련 서비스 메서드를 구현합니다.
- [x] 동일한 tmdbId는 다시 아카이빙 할 수 없도록 수정했습니다. (= 중복으로 아카이빙 하는건 안됨)

## 🧪 테스트
<!-- 어떻게 테스트했는지 적어 주세요 (Postman, 테스트 코드, 수동 확인 등) -->
Postman을 이용해 각각 API 테스트 완료했습니다.

## 📝 참고 사항
<!-- 리뷰어가 알아야 할 사항, 스크린샷, 논의할 점 등 -->