### PR TITLE
MVP1.0 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // spring session jdbc

--- a/src/main/java/org/example/cinemanote/CinemaNoteApplication.java
+++ b/src/main/java/org/example/cinemanote/CinemaNoteApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class CinemaNoteApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/cinemanote/domain/shareLink/dto/response/ShareLinkResponse.java
+++ b/src/main/java/org/example/cinemanote/domain/shareLink/dto/response/ShareLinkResponse.java
@@ -1,5 +1,6 @@
 package org.example.cinemanote.domain.shareLink.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import org.example.cinemanote.domain.shareLink.entity.ShareLink;
 
@@ -11,6 +12,7 @@ public class ShareLinkResponse {
     private final String shareToken;
     private final String shareUrl;
     private final LocalDateTime expiresAt;
+    @JsonProperty("isActive")
     private final boolean isActive;
 
     private ShareLinkResponse(ShareLink shareLink) {

--- a/src/main/java/org/example/cinemanote/global/config/JpaAuditingConfiguration.java
+++ b/src/main/java/org/example/cinemanote/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package org.example.cinemanote.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/test/java/org/example/cinemanote/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/example/cinemanote/auth/controller/AuthControllerTest.java
@@ -1,0 +1,176 @@
+package org.example.cinemanote.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.cinemanote.auth.service.AuthService;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.domain.user.repository.UserRepository;
+import org.example.cinemanote.global.common.UserRole;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+// SecurityAutoConfiguration을 제외해야 하는 이유:
+// @WebMvcTest는 @Configuration @EnableWebSecurity인 SecurityConfig를 스캔 대상에서 제외한다.
+// 그 결과 Spring Boot 기본 보안 설정(CSRF ON, 전체 인증 필요)이 적용되어 POST 요청이 403을 반환한다.
+// 컨트롤러 단위 테스트에서는 Spring Security를 제외하고, 미인증은 AuthUserArgumentResolver가 처리한다.
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+class AuthControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean AuthService authService;
+    @MockitoBean UserRepository userRepository; // AuthUserArgumentResolver 의존성
+
+    private User buildUser() {
+        return User.of("test@test.com", "encoded", "tester", UserRole.USER);
+    }
+
+    // ─── POST /signup ─────────────────────────────────────────
+
+    @Test
+    void signup_정상_요청() throws Exception {
+        given(authService.signup(any())).willReturn(buildUser());
+
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "test@test.com",
+                                        "password", "Password1!",
+                                        "nickname", "tester"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                .andExpect(jsonPath("$.data.nickname").value("tester"))
+                .andExpect(jsonPath("$.data.userRole").value("USER"));
+    }
+
+    @Test
+    void signup_nickname_빈값_400() throws Exception {
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "test@test.com",
+                                        "password", "Password1!",
+                                        "nickname", ""))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void signup_email_형식_오류_400() throws Exception {
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "not-an-email",
+                                        "password", "Password1!",
+                                        "nickname", "tester"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void signup_password_패턴_불일치_400() throws Exception {
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "test@test.com",
+                                        "password", "weak",
+                                        "nickname", "tester"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void signup_이메일_중복_409() throws Exception {
+        given(authService.signup(any())).willThrow(new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS));
+
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "dup@test.com",
+                                        "password", "Password1!",
+                                        "nickname", "tester"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다"));
+    }
+
+    @Test
+    void signup_빈_body_400() throws Exception {
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── POST /signin ─────────────────────────────────────────
+
+    @Test
+    void signin_정상_로그인() throws Exception {
+        given(authService.signin(any(), any())).willReturn(buildUser());
+
+        mockMvc.perform(post("/signin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "test@test.com", "password", "Password1!"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.email").value("test@test.com"));
+    }
+
+    @Test
+    void signin_비밀번호_불일치_400() throws Exception {
+        given(authService.signin(any(), any())).willThrow(new CustomException(ErrorCode.INVALID_PASSWORD));
+
+        mockMvc.perform(post("/signin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "test@test.com", "password", "wrong"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void signin_email_빈값_400() throws Exception {
+        mockMvc.perform(post("/signin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "", "password", "Password1!"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── POST /signout ────────────────────────────────────────
+
+    @Test
+    void signout_정상_로그아웃() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+
+        mockMvc.perform(post("/signout").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        assert session.isInvalid();
+    }
+}

--- a/src/test/java/org/example/cinemanote/auth/resolver/AuthUserArgumentResolverTest.java
+++ b/src/test/java/org/example/cinemanote/auth/resolver/AuthUserArgumentResolverTest.java
@@ -1,0 +1,128 @@
+package org.example.cinemanote.auth.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.example.cinemanote.auth.annotation.AuthUser;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.domain.user.repository.UserRepository;
+import org.example.cinemanote.global.common.Const;
+import org.example.cinemanote.global.common.UserRole;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class AuthUserArgumentResolverTest {
+
+    @Mock UserRepository userRepository;
+    @InjectMocks AuthUserArgumentResolver resolver;
+
+    @Mock NativeWebRequest webRequest;
+    @Mock HttpServletRequest httpServletRequest;
+    @Mock ModelAndViewContainer mavContainer;
+    @Mock WebDataBinderFactory binderFactory;
+
+    // ─── supportsParameter ────────────────────────────────────
+
+    @Test
+    void supportsParameter_AuthUser_User타입_true() throws Exception {
+        Method method = TestController.class.getMethod("withAuthUser", User.class);
+        MethodParameter param = new MethodParameter(method, 0);
+
+        assertThat(resolver.supportsParameter(param)).isTrue();
+    }
+
+    @Test
+    void supportsParameter_AuthUser_없음_false() throws Exception {
+        Method method = TestController.class.getMethod("withoutAnnotation", User.class);
+        MethodParameter param = new MethodParameter(method, 0);
+
+        assertThat(resolver.supportsParameter(param)).isFalse();
+    }
+
+    @Test
+    void supportsParameter_AuthUser_있지만_타입이_다름_false() throws Exception {
+        Method method = TestController.class.getMethod("withAuthUserWrongType", String.class);
+        MethodParameter param = new MethodParameter(method, 0);
+
+        assertThat(resolver.supportsParameter(param)).isFalse();
+    }
+
+    // ─── resolveArgument ──────────────────────────────────────
+
+    @Test
+    void resolveArgument_정상_User_반환() throws Exception {
+        given(webRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
+        HttpSession session = mock(HttpSession.class);
+        given(httpServletRequest.getSession(false)).willReturn(session);
+        given(session.getAttribute(Const.SESSION_USER_KEY)).willReturn(1L);
+        User user = User.of("a@b.com", "pw", "nick", UserRole.USER);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        Object result = resolver.resolveArgument(null, mavContainer, webRequest, binderFactory);
+
+        assertThat(result).isEqualTo(user);
+    }
+
+    @Test
+    void resolveArgument_session이_null이면_SESSION_NOT_FOUND() {
+        given(webRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
+        given(httpServletRequest.getSession(false)).willReturn(null);
+
+        assertThatThrownBy(() -> resolver.resolveArgument(null, mavContainer, webRequest, binderFactory))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Test
+    void resolveArgument_session에_userId_없으면_USERID_NOT_FOUND() {
+        given(webRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
+        HttpSession session = mock(HttpSession.class);
+        given(httpServletRequest.getSession(false)).willReturn(session);
+        given(session.getAttribute(Const.SESSION_USER_KEY)).willReturn(null);
+
+        assertThatThrownBy(() -> resolver.resolveArgument(null, mavContainer, webRequest, binderFactory))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USERID_NOT_FOUND));
+    }
+
+    @Test
+    void resolveArgument_userId로_유저_미조회시_USER_NOT_FOUND() {
+        given(webRequest.getNativeRequest(HttpServletRequest.class)).willReturn(httpServletRequest);
+        HttpSession session = mock(HttpSession.class);
+        given(httpServletRequest.getSession(false)).willReturn(session);
+        given(session.getAttribute(Const.SESSION_USER_KEY)).willReturn(999L);
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> resolver.resolveArgument(null, mavContainer, webRequest, binderFactory))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // ─── 테스트용 더미 컨트롤러 (MethodParameter 생성에 사용) ──
+
+    static class TestController {
+        public void withAuthUser(@AuthUser User user) {}
+        public void withoutAnnotation(User user) {}
+        public void withAuthUserWrongType(@AuthUser String name) {}
+    }
+}

--- a/src/test/java/org/example/cinemanote/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/cinemanote/auth/service/AuthServiceTest.java
@@ -1,0 +1,145 @@
+package org.example.cinemanote.auth.service;
+
+import jakarta.servlet.http.HttpSession;
+import org.example.cinemanote.auth.dto.SigninRequest;
+import org.example.cinemanote.auth.dto.SignupRequest;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.domain.user.repository.UserRepository;
+import org.example.cinemanote.global.common.Const;
+import org.example.cinemanote.global.common.UserRole;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock AuthenticationManager authenticationManager;
+    @InjectMocks AuthService authService;
+
+    // ─── signup ───────────────────────────────────────────────
+
+    @Test
+    void signup_정상_회원가입() {
+        SignupRequest req = new SignupRequest("a@b.com", "Password1!", "nick");
+        given(userRepository.existsByEmail("a@b.com")).willReturn(false);
+        given(passwordEncoder.encode("Password1!")).willReturn("encoded");
+        User saved = User.of("a@b.com", "encoded", "nick", UserRole.USER);
+        given(userRepository.save(any())).willReturn(saved);
+
+        User result = authService.signup(req);
+
+        assertThat(result.getEmail()).isEqualTo("a@b.com");
+        assertThat(result.getNickname()).isEqualTo("nick");
+        assertThat(result.getUserRole()).isEqualTo(UserRole.USER);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void signup_비밀번호가_인코딩되어_저장된다() {
+        given(userRepository.existsByEmail(any())).willReturn(false);
+        given(passwordEncoder.encode("Password1!")).willReturn("encoded");
+        given(userRepository.save(any())).willReturn(User.of("a@b.com", "encoded", "nick", UserRole.USER));
+
+        authService.signup(new SignupRequest("a@b.com", "Password1!", "nick"));
+
+        verify(passwordEncoder).encode("Password1!");
+    }
+
+    @Test
+    void signup_이메일_중복_예외() {
+        given(userRepository.existsByEmail("a@b.com")).willReturn(true);
+
+        assertThatThrownBy(() -> authService.signup(new SignupRequest("a@b.com", "Password1!", "nick")))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.EMAIL_ALREADY_EXISTS));
+
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void signup_저장된_유저의_역할은_USER() {
+        given(userRepository.existsByEmail(any())).willReturn(false);
+        given(passwordEncoder.encode(any())).willReturn("encoded");
+        given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+
+        User result = authService.signup(new SignupRequest("a@b.com", "Password1!", "nick"));
+
+        assertThat(result.getUserRole()).isEqualTo(UserRole.USER);
+    }
+
+    // ─── signin ───────────────────────────────────────────────
+
+    @Test
+    void signin_정상_로그인() {
+        Authentication auth = mock(Authentication.class);
+        given(auth.getName()).willReturn("1");
+        given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).willReturn(auth);
+        User user = User.of("a@b.com", "encoded", "nick", UserRole.USER);
+        given(userRepository.findByEmail("a@b.com")).willReturn(Optional.of(user));
+        HttpSession session = mock(HttpSession.class);
+
+        User result = authService.signin(new SigninRequest("a@b.com", "pass"), session);
+
+        assertThat(result).isEqualTo(user);
+        verify(session).setAttribute(eq(Const.SESSION_USER_KEY), any());
+    }
+
+    @Test
+    void signin_세션에_userId가_저장된다() {
+        Authentication auth = mock(Authentication.class);
+        given(auth.getName()).willReturn("42");
+        given(authenticationManager.authenticate(any())).willReturn(auth);
+        given(userRepository.findByEmail(any())).willReturn(
+                Optional.of(User.of("a@b.com", "encoded", "nick", UserRole.USER)));
+        HttpSession session = mock(HttpSession.class);
+
+        authService.signin(new SigninRequest("a@b.com", "pass"), session);
+
+        verify(session).setAttribute(eq(Const.SESSION_USER_KEY), eq(42L));
+    }
+
+    @Test
+    void signin_비밀번호_불일치_예외() {
+        given(authenticationManager.authenticate(any())).willThrow(new BadCredentialsException("bad credentials"));
+        HttpSession session = mock(HttpSession.class);
+
+        assertThatThrownBy(() -> authService.signin(new SigninRequest("a@b.com", "wrong"), session))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_PASSWORD));
+    }
+
+    @Test
+    void signin_기타_인증_실패_예외() {
+        given(authenticationManager.authenticate(any())).willThrow(new AuthenticationException("fail") {});
+        HttpSession session = mock(HttpSession.class);
+
+        assertThatThrownBy(() -> authService.signin(new SigninRequest("a@b.com", "pass"), session))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.AUTHENTICATION_FAILED));
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/archive/controller/ArchiveControllerTest.java
+++ b/src/test/java/org/example/cinemanote/domain/archive/controller/ArchiveControllerTest.java
@@ -1,0 +1,250 @@
+package org.example.cinemanote.domain.archive.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
+import org.example.cinemanote.domain.archive.dto.response.ArchiveResponse;
+import org.example.cinemanote.domain.archive.entity.Archive;
+import org.example.cinemanote.domain.archive.service.ArchiveService;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.domain.user.repository.UserRepository;
+import org.example.cinemanote.global.common.Const;
+import org.example.cinemanote.global.common.UserRole;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.example.cinemanote.global.response.PageResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+
+@WebMvcTest(
+        controllers = ArchiveController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+class ArchiveControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean ArchiveService archiveService;
+    @MockitoBean UserRepository userRepository;
+
+    private User testUser;
+    private MockHttpSession session;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.of("test@test.com", "pw", "tester", UserRole.USER);
+        ReflectionTestUtils.setField(testUser, "id", 1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        session = new MockHttpSession();
+        session.setAttribute(Const.SESSION_USER_KEY, 1L);
+    }
+
+    // ─── GET /api/archives ────────────────────────────────────
+
+    @Test
+    void getArchives_정상_조회() throws Exception {
+        Archive archive = buildArchive(1L, testUser);
+        PageResponse<ArchiveResponse> page = PageResponse.from(
+                new PageImpl<>(List.of(ArchiveResponse.from(archive)), PageRequest.of(0, 10), 1));
+        given(archiveService.getArchives(any(), any())).willReturn(page);
+
+        mockMvc.perform(get("/api/archives").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+    }
+
+    @Test
+    void getArchives_미인증_세션없음_401() throws Exception {
+        // 세션 없이 요청 → AuthUserArgumentResolver가 SESSION_NOT_FOUND(401) 발생
+        mockMvc.perform(get("/api/archives"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── GET /api/archives/{id} ───────────────────────────────
+
+    @Test
+    void getArchive_정상_조회() throws Exception {
+        Archive archive = buildArchive(1L, testUser);
+        given(archiveService.getArchive(any(), eq(1L))).willReturn(ArchiveResponse.from(archive));
+
+        mockMvc.perform(get("/api/archives/1").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.title").value("Inception"));
+    }
+
+    @Test
+    void getArchive_존재하지_않는_ID_404() throws Exception {
+        given(archiveService.getArchive(any(), eq(999L)))
+                .willThrow(new CustomException(ErrorCode.ARCHIVE_NOT_FOUND));
+
+        mockMvc.perform(get("/api/archives/999").session(session))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void getArchive_타인_아카이브_403() throws Exception {
+        given(archiveService.getArchive(any(), eq(2L)))
+                .willThrow(new CustomException(ErrorCode.ARCHIVE_ACCESS_DENIED));
+
+        mockMvc.perform(get("/api/archives/2").session(session))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── POST /api/archives ───────────────────────────────────
+
+    @Test
+    void createArchive_정상_생성_201() throws Exception {
+        Archive archive = buildArchive(1L, testUser);
+        given(archiveService.createArchive(any(), any())).willReturn(Mono.just(ArchiveResponse.from(archive)));
+
+        // Mono 반환 컨트롤러는 Spring MVC가 비동기로 처리한다.
+        // perform()은 AsyncContext 시작 시점에 리턴되므로 응답 바디가 아직 비어있다.
+        // asyncDispatch()로 Mono 구독 완료 후 응답을 검증해야 한다.
+        MvcResult asyncResult = mockMvc.perform(post("/api/archives").session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("tmdbId", 123, "contentType", "MOVIE",
+                                        "rating", 8.0, "review", "good"))))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        mockMvc.perform(asyncDispatch(asyncResult))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void createArchive_중복_409() throws Exception {
+        given(archiveService.createArchive(any(), any()))
+                .willThrow(new CustomException(ErrorCode.ARCHIVE_ALREADY_EXISTS));
+
+        mockMvc.perform(post("/api/archives").session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("tmdbId", 123, "contentType", "MOVIE",
+                                        "rating", 8.0, "review", "good"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void createArchive_미인증_401() throws Exception {
+        // 세션 없이 요청 → SESSION_NOT_FOUND(401)
+        mockMvc.perform(post("/api/archives")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ─── DELETE /api/archives/{id} ────────────────────────────
+
+    @Test
+    void deleteArchive_정상_삭제_200() throws Exception {
+        mockMvc.perform(delete("/api/archives/1").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(archiveService).deleteArchive(any(), eq(1L));
+    }
+
+    @Test
+    void deleteArchive_존재하지_않는_ID_404() throws Exception {
+        org.mockito.Mockito.doThrow(new CustomException(ErrorCode.ARCHIVE_NOT_FOUND))
+                .when(archiveService).deleteArchive(any(), eq(999L));
+
+        mockMvc.perform(delete("/api/archives/999").session(session))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void deleteArchive_타인_아카이브_403() throws Exception {
+        org.mockito.Mockito.doThrow(new CustomException(ErrorCode.ARCHIVE_ACCESS_DENIED))
+                .when(archiveService).deleteArchive(any(), eq(2L));
+
+        mockMvc.perform(delete("/api/archives/2").session(session))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── PATCH /api/archives/{id} ─────────────────────────────
+
+    @Test
+    void updateArchive_정상_수정_200() throws Exception {
+        Archive updated = buildArchive(1L, testUser);
+        updated.update(9.5f, "수정된 리뷰");
+        given(archiveService.updateArchive(any(), eq(1L), any())).willReturn(ArchiveResponse.from(updated));
+
+        mockMvc.perform(patch("/api/archives/1").session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("rating", 9.5, "review", "수정된 리뷰"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.rating").value(9.5))
+                .andExpect(jsonPath("$.data.review").value("수정된 리뷰"));
+    }
+
+    @Test
+    void updateArchive_rating_범위초과_400() throws Exception {
+        mockMvc.perform(patch("/api/archives/1").session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("rating", 11.0, "review", "리뷰"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void updateArchive_rating_음수_400() throws Exception {
+        mockMvc.perform(patch("/api/archives/1").session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("rating", -1.0, "review", "리뷰"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── 헬퍼 메서드 ─────────────────────────────────────────
+
+    private Archive buildArchive(Long id, User user) {
+        Archive archive = Archive.of(user, 123L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "overview", LocalDate.of(2010, 7, 16), 8.0f, "good");
+        ReflectionTestUtils.setField(archive, "id", id);
+        return archive;
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/archive/entity/ArchiveTest.java
+++ b/src/test/java/org/example/cinemanote/domain/archive/entity/ArchiveTest.java
@@ -1,0 +1,92 @@
+package org.example.cinemanote.domain.archive.entity;
+
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.global.common.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArchiveTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.of("test@test.com", "pw", "tester", UserRole.USER);
+    }
+
+    @Test
+    void of_모든_필드_정상_설정() {
+        LocalDate releaseDate = LocalDate.of(2010, 7, 16);
+
+        Archive archive = Archive.of(user, 123L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "꿈 속의 꿈", releaseDate, 9.0f, "명작");
+
+        assertThat(archive.getUser()).isEqualTo(user);
+        assertThat(archive.getTmdbId()).isEqualTo(123L);
+        assertThat(archive.getContentType()).isEqualTo(ContentType.MOVIE);
+        assertThat(archive.getTitle()).isEqualTo("Inception");
+        assertThat(archive.getPosterPath()).isEqualTo("/poster.jpg");
+        assertThat(archive.getOverview()).isEqualTo("꿈 속의 꿈");
+        assertThat(archive.getReleaseDate()).isEqualTo(releaseDate);
+        assertThat(archive.getRating()).isEqualTo(9.0f);
+        assertThat(archive.getReview()).isEqualTo("명작");
+    }
+
+    @Test
+    void of_poster와_releaseDate가_null인_경우() {
+        Archive archive = Archive.of(user, 456L, ContentType.TV,
+                "Breaking Bad", null, "마약 드라마", null, 10.0f, "최고");
+
+        assertThat(archive.getPosterPath()).isNull();
+        assertThat(archive.getReleaseDate()).isNull();
+    }
+
+    @Test
+    void update_rating과_review가_변경된다() {
+        Archive archive = Archive.of(user, 123L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "overview", LocalDate.now(), 5.0f, "처음 리뷰");
+
+        archive.update(9.5f, "수정된 리뷰");
+
+        assertThat(archive.getRating()).isEqualTo(9.5f);
+        assertThat(archive.getReview()).isEqualTo("수정된 리뷰");
+    }
+
+    @Test
+    void update_rating_경계값_0() {
+        Archive archive = Archive.of(user, 1L, ContentType.MOVIE,
+                "title", null, null, null, 5.0f, null);
+
+        archive.update(0.0f, null);
+
+        assertThat(archive.getRating()).isEqualTo(0.0f);
+    }
+
+    @Test
+    void update_rating_경계값_10() {
+        Archive archive = Archive.of(user, 1L, ContentType.MOVIE,
+                "title", null, null, null, 5.0f, null);
+
+        archive.update(10.0f, "perfect");
+
+        assertThat(archive.getRating()).isEqualTo(10.0f);
+        assertThat(archive.getReview()).isEqualTo("perfect");
+    }
+
+    @Test
+    void update_다른_필드는_변경되지_않는다() {
+        Archive archive = Archive.of(user, 123L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "overview", LocalDate.of(2010, 7, 16), 5.0f, "original");
+
+        archive.update(8.0f, "updated");
+
+        assertThat(archive.getTitle()).isEqualTo("Inception");
+        assertThat(archive.getTmdbId()).isEqualTo(123L);
+        assertThat(archive.getContentType()).isEqualTo(ContentType.MOVIE);
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/archive/service/ArchiveServiceTest.java
+++ b/src/test/java/org/example/cinemanote/domain/archive/service/ArchiveServiceTest.java
@@ -1,0 +1,308 @@
+package org.example.cinemanote.domain.archive.service;
+
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveUpdateRequest;
+import org.example.cinemanote.domain.archive.dto.response.ArchiveResponse;
+import org.example.cinemanote.domain.archive.entity.Archive;
+import org.example.cinemanote.domain.archive.repository.ArchiveRepository;
+import org.example.cinemanote.domain.tmdb.dto.response.TmdbMovieDetailResponse;
+import org.example.cinemanote.domain.tmdb.dto.response.TmdbTvDetailResponse;
+import org.example.cinemanote.domain.tmdb.service.TmdbMovieService;
+import org.example.cinemanote.domain.tmdb.service.TmdbTvService;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.global.common.UserRole;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.example.cinemanote.global.response.PageResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArchiveServiceTest {
+
+    @Mock ArchiveRepository archiveRepository;
+    @Mock TmdbMovieService tmdbMovieService;
+    @Mock TmdbTvService tmdbTvService;
+    @InjectMocks ArchiveService archiveService;
+
+    private User owner;
+    private User other;
+
+    @BeforeEach
+    void setUp() {
+        owner = User.of("owner@test.com", "pw", "owner", UserRole.USER);
+        ReflectionTestUtils.setField(owner, "id", 1L);
+
+        other = User.of("other@test.com", "pw", "other", UserRole.USER);
+        ReflectionTestUtils.setField(other, "id", 2L);
+    }
+
+    // ─── createArchive ────────────────────────────────────────
+
+    @Test
+    void createArchive_MOVIE_정상_생성() {
+        ArchiveCreateRequest req = buildCreateRequest(123L, ContentType.MOVIE, 8.0f, "good");
+        given(archiveRepository.existsByUserAndTmdbIdAndContentType(owner, 123L, ContentType.MOVIE))
+                .willReturn(false);
+
+        TmdbMovieDetailResponse tmdb = mock(TmdbMovieDetailResponse.class);
+        given(tmdb.getTitle()).willReturn("Inception");
+        given(tmdb.getPosterPath()).willReturn("/poster.jpg");
+        given(tmdb.getOverview()).willReturn("꿈 속의 꿈");
+        given(tmdb.getReleaseDate()).willReturn("2010-07-16");
+        given(tmdbMovieService.getMovieDetail(123L, null)).willReturn(Mono.just(tmdb));
+
+        Archive saved = Archive.of(owner, 123L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "꿈 속의 꿈", LocalDate.of(2010, 7, 16), 8.0f, "good");
+        given(archiveRepository.save(any())).willReturn(saved);
+
+        StepVerifier.create(archiveService.createArchive(owner, req))
+                .assertNext(response -> {
+                    assertThat(response.getTitle()).isEqualTo("Inception");
+                    assertThat(response.getRating()).isEqualTo(8.0f);
+                    assertThat(response.getReview()).isEqualTo("good");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void createArchive_TV_정상_생성() {
+        ArchiveCreateRequest req = buildCreateRequest(456L, ContentType.TV, 9.0f, "최고");
+        given(archiveRepository.existsByUserAndTmdbIdAndContentType(owner, 456L, ContentType.TV))
+                .willReturn(false);
+
+        TmdbTvDetailResponse tmdb = mock(TmdbTvDetailResponse.class);
+        given(tmdb.getName()).willReturn("Breaking Bad");
+        given(tmdb.getPosterPath()).willReturn("/tv-poster.jpg");
+        given(tmdb.getOverview()).willReturn("마약 드라마");
+        given(tmdb.getFirstAirDate()).willReturn("2008-01-20");
+        given(tmdbTvService.getTvDetail(456L, null)).willReturn(Mono.just(tmdb));
+
+        Archive saved = Archive.of(owner, 456L, ContentType.TV,
+                "Breaking Bad", "/tv-poster.jpg", "마약 드라마", LocalDate.of(2008, 1, 20), 9.0f, "최고");
+        given(archiveRepository.save(any())).willReturn(saved);
+
+        StepVerifier.create(archiveService.createArchive(owner, req))
+                .assertNext(response -> {
+                    assertThat(response.getTitle()).isEqualTo("Breaking Bad");
+                    assertThat(response.getRating()).isEqualTo(9.0f);
+                })
+                .verifyComplete();
+
+        verify(tmdbTvService).getTvDetail(456L, null);
+        verify(tmdbMovieService, never()).getMovieDetail(any(), any());
+    }
+
+    @Test
+    void createArchive_중복_아카이브_동기_예외() {
+        ArchiveCreateRequest req = buildCreateRequest(123L, ContentType.MOVIE, 8.0f, "good");
+        given(archiveRepository.existsByUserAndTmdbIdAndContentType(owner, 123L, ContentType.MOVIE))
+                .willReturn(true);
+
+        assertThatThrownBy(() -> archiveService.createArchive(owner, req))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ARCHIVE_ALREADY_EXISTS));
+    }
+
+    @Test
+    void createArchive_releaseDate가_null이어도_정상_생성() {
+        ArchiveCreateRequest req = buildCreateRequest(789L, ContentType.MOVIE, 7.0f, null);
+        given(archiveRepository.existsByUserAndTmdbIdAndContentType(owner, 789L, ContentType.MOVIE))
+                .willReturn(false);
+
+        TmdbMovieDetailResponse tmdb = mock(TmdbMovieDetailResponse.class);
+        given(tmdb.getTitle()).willReturn("Test Movie");
+        given(tmdb.getPosterPath()).willReturn(null);
+        given(tmdb.getOverview()).willReturn(null);
+        given(tmdb.getReleaseDate()).willReturn(null);
+        given(tmdbMovieService.getMovieDetail(789L, null)).willReturn(Mono.just(tmdb));
+
+        Archive saved = Archive.of(owner, 789L, ContentType.MOVIE, "Test Movie", null, null, null, 7.0f, null);
+        given(archiveRepository.save(any())).willReturn(saved);
+
+        StepVerifier.create(archiveService.createArchive(owner, req))
+                .assertNext(response -> assertThat(response.getTitle()).isEqualTo("Test Movie"))
+                .verifyComplete();
+    }
+
+    // ─── getArchive ───────────────────────────────────────────
+
+    @Test
+    void getArchive_정상_조회() {
+        Archive archive = buildArchive(1L, owner);
+        given(archiveRepository.findById(1L)).willReturn(Optional.of(archive));
+
+        ArchiveResponse result = archiveService.getArchive(owner, 1L);
+
+        assertThat(result.getTitle()).isEqualTo("Inception");
+    }
+
+    @Test
+    void getArchive_존재하지_않는_ID() {
+        given(archiveRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> archiveService.getArchive(owner, 999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ARCHIVE_NOT_FOUND));
+    }
+
+    @Test
+    void getArchive_타인_아카이브_접근_금지() {
+        Archive archive = buildArchive(1L, owner);
+        given(archiveRepository.findById(1L)).willReturn(Optional.of(archive));
+
+        assertThatThrownBy(() -> archiveService.getArchive(other, 1L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ARCHIVE_ACCESS_DENIED));
+    }
+
+    // ─── getArchives ──────────────────────────────────────────
+
+    @Test
+    void getArchives_목록_정상_반환() {
+        Archive a1 = buildArchive(1L, owner);
+        Archive a2 = buildArchive(2L, owner);
+        PageRequest pageable = PageRequest.of(0, 10);
+        given(archiveRepository.findAllByUser(owner, pageable))
+                .willReturn(new PageImpl<>(List.of(a1, a2), pageable, 2));
+
+        PageResponse<ArchiveResponse> result = archiveService.getArchives(owner, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    void getArchives_빈_목록() {
+        PageRequest pageable = PageRequest.of(0, 10);
+        given(archiveRepository.findAllByUser(owner, pageable))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        PageResponse<ArchiveResponse> result = archiveService.getArchives(owner, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    // ─── deleteArchive ────────────────────────────────────────
+
+    @Test
+    void deleteArchive_정상_삭제() {
+        Archive archive = buildArchive(1L, owner);
+        given(archiveRepository.findById(1L)).willReturn(Optional.of(archive));
+
+        archiveService.deleteArchive(owner, 1L);
+
+        verify(archiveRepository).delete(archive);
+    }
+
+    @Test
+    void deleteArchive_존재하지_않는_ID() {
+        given(archiveRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> archiveService.deleteArchive(owner, 999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ARCHIVE_NOT_FOUND));
+
+        verify(archiveRepository, never()).delete(any());
+    }
+
+    @Test
+    void deleteArchive_타인_아카이브_삭제_금지() {
+        Archive archive = buildArchive(1L, owner);
+        given(archiveRepository.findById(1L)).willReturn(Optional.of(archive));
+
+        assertThatThrownBy(() -> archiveService.deleteArchive(other, 1L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ARCHIVE_ACCESS_DENIED));
+
+        verify(archiveRepository, never()).delete(any());
+    }
+
+    // ─── updateArchive ────────────────────────────────────────
+
+    @Test
+    void updateArchive_정상_수정() {
+        Archive archive = buildArchive(1L, owner);
+        given(archiveRepository.findById(1L)).willReturn(Optional.of(archive));
+        ArchiveUpdateRequest req = buildUpdateRequest(9.5f, "수정된 리뷰");
+
+        ArchiveResponse result = archiveService.updateArchive(owner, 1L, req);
+
+        assertThat(result.getRating()).isEqualTo(9.5f);
+        assertThat(result.getReview()).isEqualTo("수정된 리뷰");
+    }
+
+    @Test
+    void updateArchive_존재하지_않는_ID() {
+        given(archiveRepository.findById(999L)).willReturn(Optional.empty());
+        ArchiveUpdateRequest req = buildUpdateRequest(9.0f, "리뷰");
+
+        assertThatThrownBy(() -> archiveService.updateArchive(owner, 999L, req))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ARCHIVE_NOT_FOUND));
+    }
+
+    @Test
+    void updateArchive_타인_아카이브_수정_금지() {
+        Archive archive = buildArchive(1L, owner);
+        given(archiveRepository.findById(1L)).willReturn(Optional.of(archive));
+        ArchiveUpdateRequest req = buildUpdateRequest(9.0f, "리뷰");
+
+        assertThatThrownBy(() -> archiveService.updateArchive(other, 1L, req))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ARCHIVE_ACCESS_DENIED));
+    }
+
+    // ─── 헬퍼 메서드 ─────────────────────────────────────────
+
+    private ArchiveCreateRequest buildCreateRequest(Long tmdbId, ContentType contentType, float rating, String review) {
+        ArchiveCreateRequest req = new ArchiveCreateRequest();
+        ReflectionTestUtils.setField(req, "tmdbId", tmdbId);
+        ReflectionTestUtils.setField(req, "contentType", contentType);
+        ReflectionTestUtils.setField(req, "rating", rating);
+        ReflectionTestUtils.setField(req, "review", review);
+        return req;
+    }
+
+    private ArchiveUpdateRequest buildUpdateRequest(float rating, String review) {
+        ArchiveUpdateRequest req = new ArchiveUpdateRequest();
+        ReflectionTestUtils.setField(req, "rating", rating);
+        ReflectionTestUtils.setField(req, "review", review);
+        return req;
+    }
+
+    private Archive buildArchive(Long archiveId, User user) {
+        Archive archive = Archive.of(user, 123L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "overview", LocalDate.of(2010, 7, 16), 8.0f, "original");
+        ReflectionTestUtils.setField(archive, "id", archiveId);
+        return archive;
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/shareLink/controller/ShareControllerTest.java
+++ b/src/test/java/org/example/cinemanote/domain/shareLink/controller/ShareControllerTest.java
@@ -1,0 +1,181 @@
+package org.example.cinemanote.domain.shareLink.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
+import org.example.cinemanote.domain.archive.entity.Archive;
+import org.example.cinemanote.domain.shareLink.dto.response.ShareLinkResponse;
+import org.example.cinemanote.domain.shareLink.dto.response.SharedArchivesPageResponse;
+import org.example.cinemanote.domain.shareLink.entity.ShareLink;
+import org.example.cinemanote.domain.shareLink.service.ShareService;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.domain.user.repository.UserRepository;
+import org.example.cinemanote.global.common.Const;
+import org.example.cinemanote.global.common.UserRole;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = ShareController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+class ShareControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean ShareService shareService;
+    @MockitoBean UserRepository userRepository;
+
+    private User testUser;
+    private MockHttpSession session;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.of("test@test.com", "pw", "tester", UserRole.USER);
+        ReflectionTestUtils.setField(testUser, "id", 1L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+        session = new MockHttpSession();
+        session.setAttribute(Const.SESSION_USER_KEY, 1L);
+    }
+
+    // ─── POST /api/share ──────────────────────────────────────
+
+    @Test
+    void createShareLink_정상_생성_201() throws Exception {
+        ShareLink link = ShareLink.of("test-token", testUser, null);
+        given(shareService.createShareLink(any())).willReturn(ShareLinkResponse.from(link));
+
+        mockMvc.perform(post("/api/share").session(session))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.shareToken").value("test-token"))
+                .andExpect(jsonPath("$.data.shareUrl").value("/api/share/test-token"))
+                .andExpect(jsonPath("$.data.isActive").value(true));
+    }
+
+    @Test
+    void createShareLink_미인증_세션없음_401() throws Exception {
+        // 세션 없이 요청 → AuthUserArgumentResolver가 SESSION_NOT_FOUND(401) 발생
+        mockMvc.perform(post("/api/share"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── DELETE /api/share ────────────────────────────────────
+
+    @Test
+    void deactivateShareLink_정상_비활성화_200() throws Exception {
+        mockMvc.perform(delete("/api/share").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        verify(shareService).deactivateShareLink(any());
+    }
+
+    @Test
+    void deactivateShareLink_활성_링크_없음_404() throws Exception {
+        org.mockito.Mockito.doThrow(new CustomException(ErrorCode.SHARE_LINK_NOT_FOUND))
+                .when(shareService).deactivateShareLink(any());
+
+        mockMvc.perform(delete("/api/share").session(session))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void deactivateShareLink_미인증_세션없음_401() throws Exception {
+        mockMvc.perform(delete("/api/share"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    // ─── GET /api/share/{shareToken} (인증 불필요) ────────────
+
+    @Test
+    void getSharedArchives_유효한_토큰_200() throws Exception {
+        Archive archive = buildArchive(testUser);
+        SharedArchivesPageResponse response = SharedArchivesPageResponse.of(
+                "tester", new PageImpl<>(List.of(archive), PageRequest.of(0, 10), 1));
+        given(shareService.getSharedArchives(eq("valid-token"), any())).willReturn(response);
+
+        mockMvc.perform(get("/api/share/valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.nickname").value("tester"))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+    }
+
+    @Test
+    void getSharedArchives_존재하지_않는_토큰_404() throws Exception {
+        given(shareService.getSharedArchives(eq("bad-token"), any()))
+                .willThrow(new CustomException(ErrorCode.SHARE_LINK_NOT_FOUND));
+
+        mockMvc.perform(get("/api/share/bad-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void getSharedArchives_비활성_토큰_410() throws Exception {
+        given(shareService.getSharedArchives(eq("inactive-token"), any()))
+                .willThrow(new CustomException(ErrorCode.SHARE_LINK_INACTIVE));
+
+        mockMvc.perform(get("/api/share/inactive-token"))
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void getSharedArchives_만료된_토큰_410() throws Exception {
+        given(shareService.getSharedArchives(eq("expired-token"), any()))
+                .willThrow(new CustomException(ErrorCode.SHARE_LINK_EXPIRED));
+
+        mockMvc.perform(get("/api/share/expired-token"))
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void getSharedArchives_세션_없이도_정상_조회() throws Exception {
+        SharedArchivesPageResponse response = SharedArchivesPageResponse.of(
+                "tester", new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+        given(shareService.getSharedArchives(any(), any())).willReturn(response);
+
+        // @AuthUser 파라미터가 없는 엔드포인트이므로 세션 불필요
+        mockMvc.perform(get("/api/share/some-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    // ─── 헬퍼 메서드 ─────────────────────────────────────────
+
+    private Archive buildArchive(User user) {
+        return Archive.of(user, 1L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "overview", LocalDate.of(2010, 7, 16), 8.0f, "good");
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/shareLink/entity/ShareLinkTest.java
+++ b/src/test/java/org/example/cinemanote/domain/shareLink/entity/ShareLinkTest.java
@@ -1,0 +1,68 @@
+package org.example.cinemanote.domain.shareLink.entity;
+
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.global.common.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShareLinkTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.of("test@test.com", "pw", "tester", UserRole.USER);
+    }
+
+    @Test
+    void of_모든_필드_정상_설정() {
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(7);
+
+        ShareLink link = ShareLink.of("test-token", user, expiresAt);
+
+        assertThat(link.getShareToken()).isEqualTo("test-token");
+        assertThat(link.getUser()).isEqualTo(user);
+        assertThat(link.getExpiresAt()).isEqualTo(expiresAt);
+        assertThat(link.isActive()).isTrue();
+    }
+
+    @Test
+    void of_expiresAt이_null인_경우_만료없음() {
+        ShareLink link = ShareLink.of("token", user, null);
+
+        assertThat(link.getExpiresAt()).isNull();
+        assertThat(link.isActive()).isTrue();
+    }
+
+    @Test
+    void of_생성시_isActive는_true() {
+        ShareLink link = ShareLink.of("token", user, null);
+
+        assertThat(link.isActive()).isTrue();
+    }
+
+    @Test
+    void deactivate_isActive가_false로_변경() {
+        ShareLink link = ShareLink.of("token", user, null);
+
+        link.deactivate();
+
+        assertThat(link.isActive()).isFalse();
+    }
+
+    @Test
+    void deactivate_다른_필드는_변경되지_않는다() {
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(7);
+        ShareLink link = ShareLink.of("token", user, expiresAt);
+
+        link.deactivate();
+
+        assertThat(link.getShareToken()).isEqualTo("token");
+        assertThat(link.getUser()).isEqualTo(user);
+        assertThat(link.getExpiresAt()).isEqualTo(expiresAt);
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/shareLink/service/ShareServiceTest.java
+++ b/src/test/java/org/example/cinemanote/domain/shareLink/service/ShareServiceTest.java
@@ -1,0 +1,195 @@
+package org.example.cinemanote.domain.shareLink.service;
+
+import org.example.cinemanote.domain.archive.dto.request.ArchiveCreateRequest.ContentType;
+import org.example.cinemanote.domain.archive.entity.Archive;
+import org.example.cinemanote.domain.archive.repository.ArchiveRepository;
+import org.example.cinemanote.domain.shareLink.dto.response.ShareLinkResponse;
+import org.example.cinemanote.domain.shareLink.dto.response.SharedArchivesPageResponse;
+import org.example.cinemanote.domain.shareLink.entity.ShareLink;
+import org.example.cinemanote.domain.shareLink.repository.ShareLinkRepository;
+import org.example.cinemanote.domain.user.entity.User;
+import org.example.cinemanote.global.common.UserRole;
+import org.example.cinemanote.global.exception.CustomException;
+import org.example.cinemanote.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ShareServiceTest {
+
+    @Mock ShareLinkRepository shareLinkRepository;
+    @Mock ArchiveRepository archiveRepository;
+    @InjectMocks ShareService shareService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.of("test@test.com", "pw", "tester", UserRole.USER);
+        ReflectionTestUtils.setField(user, "id", 1L);
+    }
+
+    // ─── createShareLink ──────────────────────────────────────
+
+    @Test
+    void createShareLink_신규_링크_생성() {
+        given(shareLinkRepository.findByUserAndIsActiveTrue(user)).willReturn(Optional.empty());
+        ShareLink newLink = ShareLink.of("new-token", user, null);
+        given(shareLinkRepository.save(any())).willReturn(newLink);
+
+        ShareLinkResponse result = shareService.createShareLink(user);
+
+        assertThat(result.getShareToken()).isEqualTo("new-token");
+        assertThat(result.isActive()).isTrue();
+        verify(shareLinkRepository).save(any(ShareLink.class));
+    }
+
+    @Test
+    void createShareLink_기존_활성_링크_반환() {
+        ShareLink existing = ShareLink.of("existing-token", user, null);
+        given(shareLinkRepository.findByUserAndIsActiveTrue(user)).willReturn(Optional.of(existing));
+
+        ShareLinkResponse result = shareService.createShareLink(user);
+
+        assertThat(result.getShareToken()).isEqualTo("existing-token");
+        verify(shareLinkRepository, never()).save(any());
+    }
+
+    @Test
+    void createShareLink_shareUrl_형식_검증() {
+        given(shareLinkRepository.findByUserAndIsActiveTrue(user)).willReturn(Optional.empty());
+        ShareLink link = ShareLink.of("abc-123", user, null);
+        given(shareLinkRepository.save(any())).willReturn(link);
+
+        ShareLinkResponse result = shareService.createShareLink(user);
+
+        assertThat(result.getShareUrl()).isEqualTo("/api/share/abc-123");
+    }
+
+    // ─── getSharedArchives ────────────────────────────────────
+
+    @Test
+    void getSharedArchives_정상_조회() {
+        ShareLink link = ShareLink.of("valid-token", user, null);
+        given(shareLinkRepository.findByShareToken("valid-token")).willReturn(Optional.of(link));
+        Archive archive = buildArchive(user);
+        PageRequest pageable = PageRequest.of(0, 10);
+        given(archiveRepository.findAllByUser(user, pageable))
+                .willReturn(new PageImpl<>(List.of(archive), pageable, 1));
+
+        SharedArchivesPageResponse result = shareService.getSharedArchives("valid-token", pageable);
+
+        assertThat(result.getNickname()).isEqualTo("tester");
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    void getSharedArchives_존재하지_않는_토큰() {
+        given(shareLinkRepository.findByShareToken("bad-token")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> shareService.getSharedArchives("bad-token", PageRequest.of(0, 10)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SHARE_LINK_NOT_FOUND));
+    }
+
+    @Test
+    void getSharedArchives_비활성_링크() {
+        ShareLink link = ShareLink.of("inactive-token", user, null);
+        link.deactivate();
+        given(shareLinkRepository.findByShareToken("inactive-token")).willReturn(Optional.of(link));
+
+        assertThatThrownBy(() -> shareService.getSharedArchives("inactive-token", PageRequest.of(0, 10)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SHARE_LINK_INACTIVE));
+    }
+
+    @Test
+    void getSharedArchives_만료된_링크() {
+        LocalDateTime pastTime = LocalDateTime.now().minusHours(1);
+        ShareLink link = ShareLink.of("expired-token", user, pastTime);
+        given(shareLinkRepository.findByShareToken("expired-token")).willReturn(Optional.of(link));
+
+        assertThatThrownBy(() -> shareService.getSharedArchives("expired-token", PageRequest.of(0, 10)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SHARE_LINK_EXPIRED));
+    }
+
+    @Test
+    void getSharedArchives_만료시간이_null이면_만료없이_정상_조회() {
+        ShareLink link = ShareLink.of("no-expiry-token", user, null);
+        given(shareLinkRepository.findByShareToken("no-expiry-token")).willReturn(Optional.of(link));
+        PageRequest pageable = PageRequest.of(0, 10);
+        given(archiveRepository.findAllByUser(user, pageable))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        SharedArchivesPageResponse result = shareService.getSharedArchives("no-expiry-token", pageable);
+
+        assertThat(result.getNickname()).isEqualTo("tester");
+    }
+
+    @Test
+    void getSharedArchives_미래_만료시간은_유효() {
+        LocalDateTime futureTime = LocalDateTime.now().plusDays(7);
+        ShareLink link = ShareLink.of("future-token", user, futureTime);
+        given(shareLinkRepository.findByShareToken("future-token")).willReturn(Optional.of(link));
+        PageRequest pageable = PageRequest.of(0, 10);
+        given(archiveRepository.findAllByUser(user, pageable))
+                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        SharedArchivesPageResponse result = shareService.getSharedArchives("future-token", pageable);
+
+        assertThat(result.getNickname()).isEqualTo("tester");
+    }
+
+    // ─── deactivateShareLink ──────────────────────────────────
+
+    @Test
+    void deactivateShareLink_정상_비활성화() {
+        ShareLink link = ShareLink.of("token", user, null);
+        given(shareLinkRepository.findByUserAndIsActiveTrue(user)).willReturn(Optional.of(link));
+
+        shareService.deactivateShareLink(user);
+
+        assertThat(link.isActive()).isFalse();
+    }
+
+    @Test
+    void deactivateShareLink_활성_링크_없음() {
+        given(shareLinkRepository.findByUserAndIsActiveTrue(user)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> shareService.deactivateShareLink(user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SHARE_LINK_NOT_FOUND));
+    }
+
+    // ─── 헬퍼 메서드 ─────────────────────────────────────────
+
+    private Archive buildArchive(User user) {
+        return Archive.of(user, 1L, ContentType.MOVIE,
+                "Inception", "/poster.jpg", "overview", LocalDate.of(2010, 7, 16), 8.0f, "good");
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/tmdb/service/TmdbMovieServiceTest.java
+++ b/src/test/java/org/example/cinemanote/domain/tmdb/service/TmdbMovieServiceTest.java
@@ -1,0 +1,129 @@
+package org.example.cinemanote.domain.tmdb.service;
+
+import org.example.cinemanote.domain.tmdb.client.TmdbClient;
+import org.example.cinemanote.domain.tmdb.dto.response.TmdbMovieDetailResponse;
+import org.example.cinemanote.domain.tmdb.dto.response.TmdbMovieSummaryResponse;
+import org.example.cinemanote.domain.tmdb.dto.response.TmdbPageResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TmdbMovieServiceTest {
+
+    @Mock TmdbClient tmdbClient;
+    @InjectMocks TmdbMovieService tmdbMovieService;
+
+    private static final String DEFAULT_LANG = "ko-KR";
+
+    // ─── resolveLanguage (간접 검증) ──────────────────────────
+
+    @Test
+    void searchMovies_language_null이면_기본값_koKR_사용() {
+        TmdbPageResponse<TmdbMovieSummaryResponse> mockResponse = mock(TmdbPageResponse.class);
+        given(tmdbClient.searchMovies("inception", 1, DEFAULT_LANG))
+                .willReturn(Mono.just(mockResponse));
+
+        StepVerifier.create(tmdbMovieService.searchMovies("inception", 1, null))
+                .expectNext(mockResponse)
+                .verifyComplete();
+
+        verify(tmdbClient).searchMovies("inception", 1, DEFAULT_LANG);
+    }
+
+    @Test
+    void searchMovies_language_빈문자열이면_기본값_사용() {
+        TmdbPageResponse<TmdbMovieSummaryResponse> mockResponse = mock(TmdbPageResponse.class);
+        given(tmdbClient.searchMovies("inception", 1, DEFAULT_LANG))
+                .willReturn(Mono.just(mockResponse));
+
+        StepVerifier.create(tmdbMovieService.searchMovies("inception", 1, ""))
+                .expectNext(mockResponse)
+                .verifyComplete();
+
+        verify(tmdbClient).searchMovies("inception", 1, DEFAULT_LANG);
+    }
+
+    @Test
+    void searchMovies_language_공백이면_기본값_사용() {
+        TmdbPageResponse<TmdbMovieSummaryResponse> mockResponse = mock(TmdbPageResponse.class);
+        given(tmdbClient.searchMovies("inception", 1, DEFAULT_LANG))
+                .willReturn(Mono.just(mockResponse));
+
+        StepVerifier.create(tmdbMovieService.searchMovies("inception", 1, "  "))
+                .expectNext(mockResponse)
+                .verifyComplete();
+    }
+
+    @Test
+    void searchMovies_language_명시적_지정시_그대로_사용() {
+        TmdbPageResponse<TmdbMovieSummaryResponse> mockResponse = mock(TmdbPageResponse.class);
+        given(tmdbClient.searchMovies("inception", 1, "en-US"))
+                .willReturn(Mono.just(mockResponse));
+
+        StepVerifier.create(tmdbMovieService.searchMovies("inception", 1, "en-US"))
+                .expectNext(mockResponse)
+                .verifyComplete();
+
+        verify(tmdbClient).searchMovies("inception", 1, "en-US");
+    }
+
+    // ─── getMovieDetail ───────────────────────────────────────
+
+    @Test
+    void getMovieDetail_정상_호출() {
+        TmdbMovieDetailResponse mockDetail = mock(TmdbMovieDetailResponse.class);
+        given(tmdbClient.getMovieDetail(123L, DEFAULT_LANG))
+                .willReturn(Mono.just(mockDetail));
+
+        StepVerifier.create(tmdbMovieService.getMovieDetail(123L, null))
+                .expectNext(mockDetail)
+                .verifyComplete();
+    }
+
+    @Test
+    void getMovieDetail_language_전달_시_그대로_사용() {
+        TmdbMovieDetailResponse mockDetail = mock(TmdbMovieDetailResponse.class);
+        given(tmdbClient.getMovieDetail(123L, "en-US"))
+                .willReturn(Mono.just(mockDetail));
+
+        StepVerifier.create(tmdbMovieService.getMovieDetail(123L, "en-US"))
+                .expectNext(mockDetail)
+                .verifyComplete();
+
+        verify(tmdbClient).getMovieDetail(123L, "en-US");
+    }
+
+    // ─── getPopularMovies ─────────────────────────────────────
+
+    @Test
+    void getPopularMovies_language_null이면_기본값_사용() {
+        TmdbPageResponse<TmdbMovieSummaryResponse> mockResponse = mock(TmdbPageResponse.class);
+        given(tmdbClient.getPopularMovies(1, DEFAULT_LANG)).willReturn(Mono.just(mockResponse));
+
+        StepVerifier.create(tmdbMovieService.getPopularMovies(1, null))
+                .expectNext(mockResponse)
+                .verifyComplete();
+
+        verify(tmdbClient).getPopularMovies(1, DEFAULT_LANG);
+    }
+
+    // ─── getTopRatedMovies ────────────────────────────────────
+
+    @Test
+    void getTopRatedMovies_정상_호출() {
+        TmdbPageResponse<TmdbMovieSummaryResponse> mockResponse = mock(TmdbPageResponse.class);
+        given(tmdbClient.getTopRatedMovies(1, DEFAULT_LANG)).willReturn(Mono.just(mockResponse));
+
+        StepVerifier.create(tmdbMovieService.getTopRatedMovies(1, null))
+                .expectNext(mockResponse)
+                .verifyComplete();
+    }
+}

--- a/src/test/java/org/example/cinemanote/domain/user/entity/UserTest.java
+++ b/src/test/java/org/example/cinemanote/domain/user/entity/UserTest.java
@@ -1,0 +1,55 @@
+package org.example.cinemanote.domain.user.entity;
+
+import org.example.cinemanote.global.common.UserRole;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test
+    void of_모든_필드_정상_설정() {
+        User user = User.of("test@test.com", "encodedPw", "tester", UserRole.USER);
+
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(user.getPassword()).isEqualTo("encodedPw");
+        assertThat(user.getNickname()).isEqualTo("tester");
+        assertThat(user.getUserRole()).isEqualTo(UserRole.USER);
+    }
+
+    @Test
+    void of_ADMIN_역할_설정() {
+        User user = User.of("admin@test.com", "pw", "admin", UserRole.ADMIN);
+
+        assertThat(user.getUserRole()).isEqualTo(UserRole.ADMIN);
+    }
+
+    @Test
+    void changeNickname_닉네임_변경() {
+        User user = User.of("test@test.com", "pw", "oldNick", UserRole.USER);
+
+        user.changeNickname("newNick");
+
+        assertThat(user.getNickname()).isEqualTo("newNick");
+    }
+
+    @Test
+    void changePassword_비밀번호_변경() {
+        User user = User.of("test@test.com", "oldPw", "nick", UserRole.USER);
+
+        user.changePassword("newPw");
+
+        assertThat(user.getPassword()).isEqualTo("newPw");
+    }
+
+    @Test
+    void changeNickname_기존_다른_필드는_변경되지_않는다() {
+        User user = User.of("test@test.com", "pw", "oldNick", UserRole.USER);
+
+        user.changeNickname("newNick");
+
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(user.getPassword()).isEqualTo("pw");
+        assertThat(user.getUserRole()).isEqualTo(UserRole.USER);
+    }
+}

--- a/src/test/java/org/example/cinemanote/global/exception/CustomExceptionTest.java
+++ b/src/test/java/org/example/cinemanote/global/exception/CustomExceptionTest.java
@@ -1,0 +1,74 @@
+package org.example.cinemanote.global.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomExceptionTest {
+
+    @Test
+    void 생성자_ErrorCode만_전달() {
+        CustomException ex = new CustomException(ErrorCode.ARCHIVE_NOT_FOUND);
+
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ARCHIVE_NOT_FOUND);
+        assertThat(ex.getMessage()).isEqualTo(ErrorCode.ARCHIVE_NOT_FOUND.getMessage());
+        assertThat(ex.getDetail()).isNull();
+    }
+
+    @Test
+    void 생성자_ErrorCode와_detail_전달() {
+        CustomException ex = new CustomException(ErrorCode.ARCHIVE_NOT_FOUND, "archiveId=99");
+
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ARCHIVE_NOT_FOUND);
+        assertThat(ex.getDetail()).isEqualTo("archiveId=99");
+    }
+
+    @Test
+    void getHttpStatus_UNAUTHORIZED_401() {
+        assertThat(new CustomException(ErrorCode.UNAUTHORIZED).getHttpStatus())
+                .isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void getHttpStatus_FORBIDDEN_403() {
+        assertThat(new CustomException(ErrorCode.FORBIDDEN).getHttpStatus())
+                .isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void getHttpStatus_EMAIL_ALREADY_EXISTS_409() {
+        assertThat(new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS).getHttpStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void getHttpStatus_ARCHIVE_NOT_FOUND_404() {
+        assertThat(new CustomException(ErrorCode.ARCHIVE_NOT_FOUND).getHttpStatus())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void getHttpStatus_SHARE_LINK_EXPIRED_410() {
+        assertThat(new CustomException(ErrorCode.SHARE_LINK_EXPIRED).getHttpStatus())
+                .isEqualTo(HttpStatus.GONE);
+    }
+
+    @Test
+    void getHttpStatus_SHARE_LINK_INACTIVE_410() {
+        assertThat(new CustomException(ErrorCode.SHARE_LINK_INACTIVE).getHttpStatus())
+                .isEqualTo(HttpStatus.GONE);
+    }
+
+    @Test
+    void getHttpStatus_INTERNAL_SERVER_ERROR_500() {
+        assertThat(new CustomException(ErrorCode.INTERNAL_SERVER_ERROR).getHttpStatus())
+                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void getHttpStatus_INVALID_PASSWORD_400() {
+        assertThat(new CustomException(ErrorCode.INVALID_PASSWORD).getHttpStatus())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/test/java/org/example/cinemanote/global/response/ApiResponseTest.java
+++ b/src/test/java/org/example/cinemanote/global/response/ApiResponseTest.java
@@ -1,0 +1,51 @@
+package org.example.cinemanote.global.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiResponseTest {
+
+    @Test
+    void ok_data만_전달() {
+        ApiResponse<String> response = ApiResponse.ok("hello");
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isEqualTo("hello");
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    void ok_message와_data_전달() {
+        ApiResponse<String> response = ApiResponse.ok("생성 성공", "hello");
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("생성 성공");
+        assertThat(response.getData()).isEqualTo("hello");
+    }
+
+    @Test
+    void ok_data가_null() {
+        ApiResponse<Void> response = ApiResponse.ok(null);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isNull();
+    }
+
+    @Test
+    void fail_message_전달() {
+        ApiResponse<Void> response = ApiResponse.fail("오류 발생");
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getMessage()).isEqualTo("오류 발생");
+        assertThat(response.getData()).isNull();
+        assertThat(response.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    void timestamp는_현재_시각으로_설정된다() {
+        ApiResponse<Void> response = ApiResponse.ok(null);
+        assertThat(response.getTimestamp()).isNotNull();
+    }
+}

--- a/src/test/java/org/example/cinemanote/global/response/PageResponseTest.java
+++ b/src/test/java/org/example/cinemanote/global/response/PageResponseTest.java
@@ -1,0 +1,65 @@
+package org.example.cinemanote.global.response;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PageResponseTest {
+
+    @Test
+    void from_정상_변환() {
+        List<String> content = List.of("a", "b", "c");
+        PageRequest pageable = PageRequest.of(0, 10);
+        Page<String> page = new PageImpl<>(content, pageable, 3);
+
+        PageResponse<String> response = PageResponse.from(page);
+
+        assertThat(response.getContent()).containsExactly("a", "b", "c");
+        assertThat(response.getPage()).isEqualTo(0);
+        assertThat(response.getSize()).isEqualTo(10);
+        assertThat(response.getTotalElements()).isEqualTo(3);
+        assertThat(response.getTotalPages()).isEqualTo(1);
+        assertThat(response.isLast()).isTrue();
+    }
+
+    @Test
+    void from_마지막_페이지가_아닌_경우() {
+        List<String> content = List.of("a", "b");
+        PageRequest pageable = PageRequest.of(0, 2);
+        Page<String> page = new PageImpl<>(content, pageable, 10);
+
+        PageResponse<String> response = PageResponse.from(page);
+
+        assertThat(response.isLast()).isFalse();
+        assertThat(response.getTotalPages()).isEqualTo(5);
+    }
+
+    @Test
+    void from_빈_페이지() {
+        Page<String> page = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+
+        PageResponse<String> response = PageResponse.from(page);
+
+        assertThat(response.getContent()).isEmpty();
+        assertThat(response.getTotalElements()).isEqualTo(0);
+        assertThat(response.isLast()).isTrue();
+    }
+
+    @Test
+    void from_2번째_페이지() {
+        List<Integer> content = List.of(11, 12);
+        PageRequest pageable = PageRequest.of(1, 10);
+        Page<Integer> page = new PageImpl<>(content, pageable, 22);
+
+        PageResponse<Integer> response = PageResponse.from(page);
+
+        assertThat(response.getPage()).isEqualTo(1);
+        assertThat(response.isLast()).isFalse();
+        assertThat(response.getTotalPages()).isEqualTo(3);
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,13 @@
+# Spring Session - JDBC 없이 기본 HttpSession 사용
+spring.session.store-type=none
+
+# H2 인메모리 DB (컨텍스트 로드 필요한 슬라이스 테스트용)
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# TMDB API key 더미값 (실제 API 호출 없음)
+tmdb.api-key=test-api-key

--- a/test/mvp1.0test.md
+++ b/test/mvp1.0test.md
@@ -1,0 +1,572 @@
+# CinemaNote MVP 1.0 — 테스트 계획
+
+---
+
+# Part 1. 백엔드 유닛 테스트
+
+## 테스트 환경
+
+**기술 스택:**
+- JUnit 5 (`@ExtendWith(MockitoExtension.class)`) — 서비스 단위 테스트
+- Mockito (`@Mock`, `@InjectMocks`) — 의존성 격리
+- MockMvc (`@WebMvcTest`) — 컨트롤러 슬라이스 테스트
+- StepVerifier (Reactor Test) — `Mono<T>` 반환 메서드 검증
+- H2 인메모리 DB (`@DataJpaTest`) — 리포지토리 테스트
+
+**추가 의존성 (build.gradle):**
+```groovy
+testImplementation 'io.projectreactor:reactor-test'
+testImplementation 'org.springframework.security:spring-security-test'
+```
+
+---
+
+## 1. 서비스 레이어
+
+### 1-1. `AuthService`
+
+> **전략:** `UserRepository`, `PasswordEncoder`, `AuthenticationManager`를 Mock으로 주입.
+
+#### `signup(SignupRequest)`
+
+| 테스트 케이스 | 입력 | 예상 결과 |
+|---|---|---|
+| 정상 회원가입 | 유효한 email/password/nickname | `User` 반환, `userRepository.save()` 1회 호출 |
+| 이메일 중복 | `existsByEmail()` → true | `CustomException(EMAIL_ALREADY_EXISTS)` throw |
+| 비밀번호 인코딩 확인 | 정상 입력 | `passwordEncoder.encode()` 1회 호출 |
+| 저장된 유저의 role | 정상 입력 | `UserRole.USER`로 저장됨 |
+
+```java
+// test/auth/service/AuthServiceTest.java
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock AuthenticationManager authenticationManager;
+    @InjectMocks AuthService authService;
+
+    @Test
+    void signup_정상_회원가입() {
+        // given
+        SignupRequest req = new SignupRequest("a@b.com", "Password1!", "nick");
+        given(userRepository.existsByEmail("a@b.com")).willReturn(false);
+        given(passwordEncoder.encode("Password1!")).willReturn("encoded");
+        User saved = User.of("a@b.com", "encoded", "nick", UserRole.USER);
+        given(userRepository.save(any())).willReturn(saved);
+
+        // when
+        User result = authService.signup(req);
+
+        // then
+        assertThat(result.getEmail()).isEqualTo("a@b.com");
+        assertThat(result.getUserRole()).isEqualTo(UserRole.USER);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void signup_이메일_중복_예외() {
+        given(userRepository.existsByEmail(any())).willReturn(true);
+        assertThatThrownBy(() -> authService.signup(new SignupRequest("a@b.com", "P@ssw0rd", "nick")))
+            .isInstanceOf(CustomException.class)
+            .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.EMAIL_ALREADY_EXISTS));
+    }
+}
+```
+
+#### `signin(SigninRequest, HttpSession)`
+
+| 테스트 케이스 | 입력 | 예상 결과 |
+|---|---|---|
+| 정상 로그인 | 유효한 email/password | `User` 반환, session에 userId 저장 |
+| 비밀번호 불일치 | `authenticate()` → `BadCredentialsException` | `CustomException(INVALID_PASSWORD)` throw |
+| 인증 실패 (기타) | `authenticate()` → `AuthenticationException` | `CustomException(AUTHENTICATION_FAILED)` throw |
+| 세션 저장 확인 | 정상 로그인 | `session.setAttribute(SESSION_USER_KEY, userId)` 호출됨 |
+
+---
+
+### 1-2. `ArchiveService`
+
+> **전략:** `ArchiveRepository`, `TmdbMovieService`, `TmdbTvService`를 Mock으로 주입.
+> Reactive 메서드는 `StepVerifier`로 검증.
+
+#### `createArchive(User, ArchiveCreateRequest)`
+
+| 테스트 케이스 | 입력 | 예상 결과 |
+|---|---|---|
+| 정상 생성 (MOVIE) | contentType=MOVIE, 유효한 tmdbId | `Mono<ArchiveResponse>` 반환, `save()` 호출 |
+| 정상 생성 (TV) | contentType=TV, 유효한 tmdbId | `TmdbTvService.getTvDetail()` 호출 |
+| 중복 아카이브 | `existsByUserAndTmdbIdAndContentType()` → true | `Mono.error(CustomException(ARCHIVE_ALREADY_EXISTS))` |
+| TMDB API 오류 | `getMovieDetail()` → error Mono | `Mono.error(CustomException(TMDB_API_ERROR))` |
+
+```java
+@Test
+void createArchive_중복_아카이브_예외() {
+    // given
+    User user = createMockUser();
+    ArchiveCreateRequest req = new ArchiveCreateRequest(123L, ContentType.MOVIE, 8.0f, "good");
+    given(archiveRepository.existsByUserAndTmdbIdAndContentType(user, 123L, ContentType.MOVIE))
+        .willReturn(true);
+
+    // when & then
+    StepVerifier.create(archiveService.createArchive(user, req))
+        .expectErrorSatisfies(e -> {
+            assertThat(e).isInstanceOf(CustomException.class);
+            assertThat(((CustomException) e).getErrorCode()).isEqualTo(ErrorCode.ARCHIVE_ALREADY_EXISTS);
+        })
+        .verify();
+}
+```
+
+#### `getArchive(User, Long archiveId)`
+
+| 테스트 케이스 | 입력 | 예상 결과 |
+|---|---|---|
+| 정상 조회 | 본인 아카이브 ID | `ArchiveResponse` 반환 |
+| 존재하지 않는 ID | `findById()` → empty | `CustomException(ARCHIVE_NOT_FOUND)` |
+| 타인 아카이브 접근 | 다른 유저 소유 | `CustomException(ARCHIVE_ACCESS_DENIED)` |
+
+#### `getArchives(User, Pageable)`
+
+| 테스트 케이스 | 예상 결과 |
+|---|---|
+| 아카이브 목록 존재 | `PageResponse` 반환, content 크기 일치 |
+| 빈 목록 | `PageResponse` 반환, content 빈 리스트 |
+
+#### `deleteArchive(User, Long archiveId)`
+
+| 테스트 케이스 | 예상 결과 |
+|---|---|
+| 정상 삭제 | `archiveRepository.delete()` 1회 호출 |
+| 존재하지 않는 ID | `CustomException(ARCHIVE_NOT_FOUND)` |
+| 타인 아카이브 | `CustomException(ARCHIVE_ACCESS_DENIED)` |
+
+#### `updateArchive(User, Long archiveId, ArchiveUpdateRequest)`
+
+| 테스트 케이스 | 예상 결과 |
+|---|---|
+| 정상 수정 | 수정된 `ArchiveResponse` 반환 (rating, review 변경 확인) |
+| 존재하지 않는 ID | `CustomException(ARCHIVE_NOT_FOUND)` |
+| 타인 아카이브 | `CustomException(ARCHIVE_ACCESS_DENIED)` |
+
+#### `parseDate(String)` (private → 간접 검증)
+
+| 입력 | 예상 결과 |
+|---|---|
+| `"2024-01-15"` | `LocalDate.of(2024, 1, 15)` |
+| `null` | `null` |
+| `""` | `null` |
+| 잘못된 형식 `"2024/01/15"` | `null` 또는 예외 처리 확인 |
+
+---
+
+### 1-3. `ShareService`
+
+> **전략:** `ShareLinkRepository`, `ArchiveRepository`를 Mock으로 주입.
+
+#### `createShareLink(User)`
+
+| 테스트 케이스 | 예상 결과 |
+|---|---|
+| 활성 링크 없음 | 신규 `ShareLink` 생성, UUID 토큰 포함, `save()` 호출 |
+| 활성 링크 이미 존재 | 기존 링크 반환, `save()` 미호출 |
+| 반환값 검증 | `isActive=true`, `shareToken` 비어있지 않음 |
+
+```java
+@Test
+void createShareLink_기존_활성_링크_반환() {
+    // given
+    User user = createMockUser();
+    ShareLink existing = ShareLink.of("existing-token", user, null);
+    given(shareLinkRepository.findByUserAndIsActiveTrue(user)).willReturn(Optional.of(existing));
+
+    // when
+    ShareLinkResponse result = shareService.createShareLink(user);
+
+    // then
+    assertThat(result.getShareToken()).isEqualTo("existing-token");
+    verify(shareLinkRepository, never()).save(any());
+}
+```
+
+#### `getSharedArchives(String shareToken, Pageable)`
+
+| 테스트 케이스 | 예상 결과 |
+|---|---|
+| 정상 조회 | `SharedArchivesPageResponse` 반환, nickname 포함 |
+| 존재하지 않는 토큰 | `CustomException(SHARE_LINK_NOT_FOUND)` |
+| 비활성 링크 | `CustomException(SHARE_LINK_INACTIVE)` |
+| 만료된 링크 | `expiresAt`이 현재 시각 이전 → `CustomException(SHARE_LINK_EXPIRED)` |
+| 만료 없는 링크 | `expiresAt=null` → 정상 조회 |
+
+#### `deactivateShareLink(User)`
+
+| 테스트 케이스 | 예상 결과 |
+|---|---|
+| 정상 비활성화 | `shareLink.deactivate()` 호출, `isActive=false` |
+| 활성 링크 없음 | `CustomException(SHARE_LINK_NOT_FOUND)` |
+
+---
+
+### 1-4. `TmdbMovieService` / `TmdbTvService`
+
+> **전략:** `TmdbClient`를 Mock으로 주입. `StepVerifier`로 Mono 검증.
+
+#### `resolveLanguage(String)` (private → 간접 검증)
+
+| 입력 | 예상 결과 |
+|---|---|
+| `"en-US"` | `"en-US"` (입력값 그대로) |
+| `null` | `"ko-KR"` (기본값) |
+| `""` | `"ko-KR"` (기본값) |
+| `"  "` (공백) | `"ko-KR"` (기본값) |
+
+```java
+@Test
+void searchMovies_language_null이면_기본값_사용() {
+    // given
+    given(tmdbClient.searchMovies("inception", 1, "ko-KR"))
+        .willReturn(Mono.just(mockPageResponse()));
+
+    // when & then
+    StepVerifier.create(tmdbMovieService.searchMovies("inception", 1, null))
+        .expectNextMatches(res -> res.getResults() != null)
+        .verifyComplete();
+
+    verify(tmdbClient).searchMovies("inception", 1, "ko-KR");
+}
+```
+
+---
+
+## 2. 도메인 엔티티
+
+> **전략:** 외부 의존성 없이 순수 단위 테스트.
+
+### `Archive`
+
+| 테스트 케이스 | 검증 내용 |
+|---|---|
+| `Archive.of(...)` | 모든 필드가 올바르게 설정됨 |
+| `archive.update(rating, review)` | rating, review 변경, 다른 필드 불변 |
+| `update()` — rating 경계값 | 0.0, 10.0 정상 저장 |
+
+### `ShareLink`
+
+| 테스트 케이스 | 검증 내용 |
+|---|---|
+| `ShareLink.of(token, user, expiresAt)` | 필드 설정, `isActive=true` 초기값 |
+| `shareLink.deactivate()` | `isActive=false`로 변경 |
+
+### `User`
+
+| 테스트 케이스 | 검증 내용 |
+|---|---|
+| `User.of(...)` | 모든 필드 설정, role 확인 |
+| `user.changeNickname(newNickname)` | nickname 변경 |
+| `user.changePassword(newPassword)` | password 변경 |
+
+---
+
+## 3. DTO 변환 메서드
+
+> **전략:** 실제 엔티티 인스턴스를 생성해 `from()` / `of()` 결과를 검증.
+
+### `ArchiveResponse.from(Archive)`
+
+| 검증 필드 | 내용 |
+|---|---|
+| `id`, `userId`, `title`, `posterPath` | Archive 필드와 일치 |
+| `rating`, `review`, `releaseDate` | Archive 필드와 일치 |
+| `createdAt`, `updatedAt` | BaseEntity 필드와 일치 |
+
+### `SignupResponse.from(User)` / `SigninResponse.from(User)`
+
+| 검증 필드 | 내용 |
+|---|---|
+| `id`, `email`, `nickname`, `userRole` | User 필드와 일치 |
+
+### `ShareLinkResponse.from(ShareLink)`
+
+| 검증 필드 | 내용 |
+|---|---|
+| `shareToken` | ShareLink 토큰과 일치 |
+| `shareUrl` | `"/api/share/{token}"` 형식 |
+| `isActive` | true |
+
+### `PageResponse.from(Page<T>)`
+
+| 검증 내용 |
+|---|
+| `content`, `page`, `size`, `totalElements`, `totalPages`, `last` 모두 Spring Page 값과 일치 |
+
+### `ApiResponse`
+
+| 테스트 케이스 | 검증 내용 |
+|---|---|
+| `ApiResponse.ok(data)` | `success=true`, `data` 존재, `timestamp` 비어있지 않음 |
+| `ApiResponse.ok(message, data)` | `message` 포함 |
+| `ApiResponse.fail(message)` | `success=false`, `data=null` |
+
+---
+
+## 4. 예외 처리
+
+### `GlobalExceptionHandler`
+
+> **전략:** MockMvc + `@WebMvcTest`로 실제 HTTP 응답 코드/바디 검증.
+
+| 예외 유형 | 검증 내용 |
+|---|---|
+| `CustomException(EMAIL_ALREADY_EXISTS)` | HTTP 409, `success=false`, 메시지 포함 |
+| `CustomException(ARCHIVE_NOT_FOUND)` | HTTP 404, `success=false` |
+| `MethodArgumentNotValidException` | HTTP 400, 필드 에러 메시지 포함 |
+| `HttpMessageNotReadableException` | HTTP 400 |
+| 미처리 `Exception` | HTTP 500 |
+
+```java
+// 컨트롤러 슬라이스 테스트에서 함께 검증
+mockMvc.perform(post("/signup").contentType(APPLICATION_JSON).content("{}"))
+    .andExpect(status().isBadRequest())
+    .andExpect(jsonPath("$.success").value(false))
+    .andExpect(jsonPath("$.message").isNotEmpty());
+```
+
+### `CustomException`
+
+| 테스트 케이스 | 검증 내용 |
+|---|---|
+| `UNAUTHORIZED` | `getHttpStatus()` → 401 |
+| `FORBIDDEN` | `getHttpStatus()` → 403 |
+| `EMAIL_ALREADY_EXISTS` | `getHttpStatus()` → 409 |
+| `ARCHIVE_NOT_FOUND` | `getHttpStatus()` → 404 |
+| `SHARE_LINK_EXPIRED` | `getHttpStatus()` → 410 |
+| `INTERNAL_SERVER_ERROR` | `getHttpStatus()` → 500 |
+
+---
+
+## 5. 컨트롤러 레이어
+
+> **전략:** `@WebMvcTest` + `@MockBean` 서비스. `@AuthUser` 파라미터는 `with(user(...))` 또는 MockMvc security 설정으로 처리.
+
+### `AuthController`
+
+#### `POST /signup`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 입력 | 200 | `success=true`, `data.email` 포함 |
+| email 형식 오류 | 400 | `success=false`, 검증 메시지 |
+| nickname 빈값 | 400 | `success=false` |
+| password 패턴 불일치 | 400 | `success=false` |
+| 이메일 중복 (서비스 예외) | 409 | `success=false`, 에러 메시지 |
+
+#### `POST /signin`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 로그인 | 200 | `success=true`, `data.nickname` 포함 |
+| 비밀번호 불일치 | 400 | `success=false` |
+
+#### `POST /signout`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 로그아웃 | 200 | `success=true`, `data=null` |
+
+---
+
+### `ArchiveController`
+
+#### `POST /api/archives`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 생성 | 201 | `success=true`, `data.title` 포함 |
+| `tmdbId` 누락 | 400 | `success=false` |
+| `contentType` 누락 | 400 | `success=false` |
+| `rating` 범위 초과 (11.0) | 400 | `success=false` |
+| `review` 500자 초과 | 400 | `success=false` |
+| 중복 아카이브 | 409 | `success=false` |
+| 미인증 접근 | 401 | `success=false` |
+
+#### `GET /api/archives`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 조회 | 200 | `data.content` 배열, `data.totalElements` 포함 |
+| 미인증 | 401 | `success=false` |
+
+#### `GET /api/archives/{archiveId}`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 조회 | 200 | `data.id` 일치 |
+| 존재하지 않는 ID | 404 | `success=false` |
+| 타인 아카이브 | 403 | `success=false` |
+
+#### `DELETE /api/archives/{archiveId}`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 삭제 | 200 | `success=true` |
+| 존재하지 않는 ID | 404 | `success=false` |
+| 타인 아카이브 | 403 | `success=false` |
+
+#### `PATCH /api/archives/{archiveId}`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 수정 | 200 | `data.rating`, `data.review` 변경 반영 |
+| `rating` 음수 | 400 | `success=false` |
+
+---
+
+### `ShareController`
+
+#### `POST /api/share`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 생성 | 201 | `data.shareToken` 비어있지 않음, `data.isActive=true` |
+| 미인증 | 401 | `success=false` |
+
+#### `DELETE /api/share`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 정상 비활성화 | 200 | `success=true` |
+| 활성 링크 없음 | 404 | `success=false` |
+
+#### `GET /api/share/{shareToken}` (인증 불필요)
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 유효한 토큰 | 200 | `data.nickname`, `data.content` 포함 |
+| 존재하지 않는 토큰 | 404 | `success=false` |
+| 비활성 토큰 | 410 | `success=false` |
+| 만료된 토큰 | 410 | `success=false` |
+
+---
+
+### `TmdbMovieController` / `TmdbTvController`
+
+#### `GET /api/1/movies/search`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| query 정상 | 200 | `data.results` 배열 |
+| query 누락 | 400 | `success=false` |
+| query 100자 초과 | 400 | `success=false` |
+| language 생략 | 200 | 기본 언어(`ko-KR`)로 조회 |
+
+#### `GET /api/1/movies/{movieId}`
+
+| 테스트 케이스 | HTTP Status | 검증 내용 |
+|---|---|---|
+| 유효한 movieId | 200 | `data.title` 포함 |
+| 존재하지 않는 movieId | 404 | `success=false` |
+
+> TV 엔드포인트는 동일한 패턴으로 검증 (title 대신 name 필드 확인)
+
+---
+
+## 6. `AuthUserArgumentResolver`
+
+> **전략:** `MethodParameter`, `NativeWebRequest`, `ModelAndViewContainer`를 Mock으로 주입.
+
+| 테스트 케이스 | 검증 내용 |
+|---|---|
+| `supportsParameter` — `@AuthUser User` | `true` 반환 |
+| `supportsParameter` — annotation 없음 | `false` 반환 |
+| `supportsParameter` — 다른 타입 파라미터 | `false` 반환 |
+| `resolveArgument` — 정상 세션 | `User` 반환 |
+| `resolveArgument` — session=null | `CustomException(SESSION_NOT_FOUND)` |
+| `resolveArgument` — session에 userId 없음 | `CustomException(USERID_NOT_FOUND)` |
+| `resolveArgument` — userId 있으나 DB에 없음 | `CustomException(USER_NOT_FOUND)` |
+
+```java
+@Test
+void resolveArgument_정상_세션() throws Exception {
+    // given
+    HttpServletRequest httpReq = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    given(httpReq.getSession(false)).willReturn(session);
+    given(session.getAttribute(Const.SESSION_USER_KEY)).willReturn(1L);
+    User user = User.of("a@b.com", "pw", "nick", UserRole.USER);
+    given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+    // when
+    Object result = resolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+
+    // then
+    assertThat(result).isEqualTo(user);
+}
+```
+
+---
+
+## 7. 테스트 파일 구조
+
+```
+src/test/java/org/example/cinemanote/
+├── auth/
+│   ├── service/
+│   │   └── AuthServiceTest.java
+│   └── resolver/
+│       └── AuthUserArgumentResolverTest.java
+├── domain/
+│   ├── archive/
+│   │   ├── entity/
+│   │   │   └── ArchiveTest.java
+│   │   ├── service/
+│   │   │   └── ArchiveServiceTest.java
+│   │   └── controller/
+│   │       └── ArchiveControllerTest.java
+│   ├── shareLink/
+│   │   ├── entity/
+│   │   │   └── ShareLinkTest.java
+│   │   ├── service/
+│   │   │   └── ShareServiceTest.java
+│   │   └── controller/
+│   │       └── ShareControllerTest.java
+│   ├── tmdb/
+│   │   ├── service/
+│   │   │   ├── TmdbMovieServiceTest.java
+│   │   │   └── TmdbTvServiceTest.java
+│   │   └── controller/
+│   │       ├── TmdbMovieControllerTest.java
+│   │       └── TmdbTvControllerTest.java
+│   └── user/
+│       └── entity/
+│           └── UserTest.java
+└── global/
+    ├── exception/
+    │   ├── CustomExceptionTest.java
+    │   └── GlobalExceptionHandlerTest.java
+    └── response/
+        ├── ApiResponseTest.java
+        └── PageResponseTest.java
+```
+
+---
+
+## 8. 우선순위
+
+| 순위 | 대상 | 이유 |
+|---|---|---|
+| 1 | `AuthService` | 인증은 모든 기능의 전제 조건 |
+| 2 | `ArchiveService` | 핵심 비즈니스 로직, 소유권 검증 포함 |
+| 3 | `ShareService` | 만료/비활성 등 엣지케이스 多 |
+| 4 | `AuthUserArgumentResolver` | 모든 인증 필요 엔드포인트에서 실행 |
+| 5 | `ArchiveController` | 입력 검증 케이스 多 |
+| 6 | `CustomException` / `GlobalExceptionHandler` | 에러 응답 일관성 보장 |
+| 7 | 엔티티 / DTO | 단순하지만 변환 오류 방지 |
+| 8 | TMDB 서비스/컨트롤러 | 외부 API 의존, Mock 처리 필요 |
+
+---
+
+# Part 2. 프론트엔드 유닛 테스트
+
+*추후 작성 예정*


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이 PR에서 어떤 작업을 했는지 간단히 설명해 주세요 -->
MVP 1.0 작업 내용의 유닛테스트 테스트 코드를 작성합니다.

## 🔗 관련 이슈
<!-- closes #이슈번호 를 적으면 merge 시 이슈가 자동으로 닫힙니다 -->
closes #15

## ✅ 변경 사항
<!-- 구체적으로 어떤 것들이 변경되었는지 체크리스트로 작성해 주세요 -->
- [x] CRUD(아카이빙) 도메인, 공유링크(TMDB API 포함) 도메인, 인증/인가 도메인 유닛 테스트 코드를 작성했습니다. 
- [x] JpaAuditing 설정을 따로 관리하기 위해서 configuration 파일로 구분했습니다.
- [x] sharelinkResponseDto에서 isActive 필드 사용 중 getter 사용 시 is가 빠지는 현상을 발견하여 "isActive"로 반환되도록 수정했습니다.

## 🧪 테스트
<!-- 어떻게 테스트했는지 적어 주세요 (Postman, 테스트 코드, 수동 확인 등) -->
테스트 코드로 작성했습니다.

## 📝 참고 사항
<!-- 리뷰어가 알아야 할 사항, 스크린샷, 논의할 점 등 -->